### PR TITLE
Fix code coverage report system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       - lcov --directory . --zerocounters
       - bin/test-107-Arduino-UAVCAN
       - lcov --directory . --capture --output-file coverage.info
-      - lcov --remove coverage.info 'test/*' '/usr/*' 'libcanard/*' 'o1heap/*' --output-file coverage.info
+      - lcov --remove coverage.info '*/extras/test/*' '/usr/*' '*/src/libcanard/*' '*/src/o1heap/*' --output-file coverage.info
       - lcov --list coverage.info
       - bash <(curl -s https://codecov.io/bash) -f coverage.info
       - cd ..

--- a/extras/test/CMakeLists.txt
+++ b/extras/test/CMakeLists.txt
@@ -33,6 +33,9 @@ set(TEST_SRCS
 add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 add_compile_definitions(HOST)
 
+set(CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   "--coverage")
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "--coverage")
+
 ##########################################################################
 
 add_executable(


### PR DESCRIPTION
This PR fixes some flaws and deficiencies in my previous attempt to set up code coverage reporting during the CI build.

It was necessary to add the `--coverage` option in CMakeLists.txt in order to produce the coverage data needed for the report. This was the cause of the `lcov --list coverage.info` command's failure:
```
Reading tracefile coverage.info

lcov: ERROR: no valid records found in tracefile coverage.info
```

I based the original file matching patterns in the `lcov --remove` command on the [ArduinoCloudThing CI configuration](https://github.com/arduino-libraries/ArduinoCloudThing/blob/bb8fb1ca7504507f478a3688171c867993f1ff89/.travis.yml#L23), without really understanding how that command worked, but I have since learned that they won't match the intended paths, resulting in the coverage report containing data for files that are not part of the 107-Arduino-UAVCAN source code.

The "Unit tests" job of the CI build will now produce the expected coverage report:
```
$ lcov --list coverage.info

Reading tracefile coverage.info

                         |Lines       |Functions  |Branches    

Filename                 |Rate     Num|Rate    Num|Rate     Num

===============================================================

[/home/travis/build/per1234/107-Arduino-UAVCAN/src/]

ArduinoO1Heap.cpp        | 0.0%      8| 0.0%     3|    -      0

ArduinoUAVCAN.cpp        | 0.0%     13| 0.0%     3|    -      0

===============================================================

                   Total:| 0.0%     21| 0.0%     6|    -      0
```