### PR TITLE
Fix errors in Compile Examples CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -27,6 +27,7 @@ jobs:
         uses: arduino/actions/libraries/compile-examples@master
         with:
           fqbn: arduino:samd:mkrvidor4000
+          libraries: ${{ env.LIBRARIES }}
           size-report-sketch: Orel-20-Status
           enable-size-deltas-report: true
 

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           fqbn: arduino:samd:mkrvidor4000
           libraries: ${{ env.LIBRARIES }}
-          size-report-sketch: Orel-20-Status
           enable-size-deltas-report: true
 
       - name: Save memory usage change report as artifact

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      LIBRARIES: ArduinoMCP2515
+      LIBRARIES: 107-Arduino-MCP2515
 
     steps:
       - name: Checkout

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -16,8 +16,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-   env:
-     LIBRARIES: ArduinoMCP2515
+    env:
+      LIBRARIES: ArduinoMCP2515
 
     steps:
       - name: Checkout


### PR DESCRIPTION
GitHub Actions has the unfortunate behavior of failing silently when the workflow is invalid. Although you can still see the failed runs in the "Actions" page, they don't affect the status of the CI build, so it's easy to not notice one missing workflow when you have other workflows running during the CI build.

---
There is still one outstanding issue that will cause the Compile Examples run for this PR to fail: the "size-report-sketch" used by the workflow, Orel-20-Status was removed by https://github.com/107-systems/107-Arduino-UAVCAN/commit/06f31fe729002397f51e60db64a895513bf2467e, which results in the error:
```
##[error]size-report-sketch: Orel-20-Status was not found
```
 So I need to change that to one of the existing examples. @aentinger, which of the two examples do you want to use as the size report sketch for the Report Size Deltas workflow?
- UAVCAN-Heartbeat-Publish
- UAVCAN-Heartbeat-Subscribe

Once I have done that, I'll take the PR out of draft status and it will be ready for merge