### PR TITLE
Compile examples for Portenta H7 in CI workflow runs

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -25,8 +25,10 @@ jobs:
       matrix:
         fqbn:
           - "arduino:samd:mkrvidor4000"
+          # These should be changed from to the "arduino-beta" vendor to "arduino" once there is a production release of Arduino mbed-Enabled Boards
           - "arduino-beta:mbed:envie_m7"
           - "arduino-beta:mbed:envie_m4"
+          - "arduino-beta:mbed:nano33ble"
 
     steps:
       - name: Checkout

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -19,6 +19,15 @@ jobs:
     env:
       LIBRARIES: 107-Arduino-MCP2515
 
+    strategy:
+      fail-fast: false
+
+      matrix:
+        fqbn:
+          - "arduino:samd:mkrvidor4000"
+          - "arduino-beta:mbed:envie_m7"
+          - "arduino-beta:mbed:envie_m4"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -26,7 +35,7 @@ jobs:
       - name: Compile examples
         uses: arduino/actions/libraries/compile-examples@master
         with:
-          fqbn: arduino:samd:mkrvidor4000
+          fqbn: ${{ matrix.fqbn }}
           libraries: ${{ env.LIBRARIES }}
           enable-size-deltas-report: true
 


### PR DESCRIPTION
Compile for both the Portenta H7's M7 and M4 cores.

Fixes https://github.com/107-systems/107-Arduino-UAVCAN/issues/35

Demonstration of passing workflow run when this is rebased on https://github.com/107-systems/107-Arduino-UAVCAN/pull/34:
https://github.com/per1234/107-Arduino-UAVCAN/actions/runs/216129046

---
NOTE: https://github.com/107-systems/107-Arduino-UAVCAN/pull/35 says " add CI for Portenta H7", but it also says "have the examples built for that core and all it's targets?". In addition to the Portenta H7, arduino/ArduinoCore-mbed [also supports the Nano 33 BLE](https://github.com/arduino/ArduinoCore-mbed/blob/ffe63eb7be8f00839436160482842e3e9e1df0c5/boards.txt#L95). Did you also want me to add that board to the compile examples workflow, or only the Portenta?