### PR TITLE
Unify Ctor structure (only default/copy-ctor)

### DIFF
--- a/examples/UAVCAN-Heartbeat-Publish/UAVCAN-Heartbeat-Publish.ino
+++ b/examples/UAVCAN-Heartbeat-Publish/UAVCAN-Heartbeat-Publish.ino
@@ -44,7 +44,7 @@ ArduinoMCP2515 mcp2515(spi_select,
 
 ArduinoUAVCAN uavcan(13, micros, transmitCanFrame);
 
-Heartbeat_1_0 hb(0, Heartbeat_1_0::Health::NOMINAL, Heartbeat_1_0::Mode::INITIALIZATION, 0);
+Heartbeat_1_0 hb;
 
 /**************************************************************************************
  * SETUP/LOOP
@@ -68,13 +68,19 @@ void setup()
   mcp2515.begin();
   mcp2515.setBitRate(CanBitRate::BR_250kBPS);
   mcp2515.setNormalMode();
+
+  /* Configure initial heartbeat */
+  hb.data.uptime = 0;
+  hb = Heartbeat_1_0::Health::NOMINAL;
+  hb = Heartbeat_1_0::Mode::INITIALIZATION;
+  hb.data.vendor_specific_status_code = 0;
 }
 
 void loop()
 {
   /* Update the heartbeat object */
   hb.data.uptime = millis() / 1000;
-  hb.data.mode = to_integer(Heartbeat_1_0::Mode::OPERATIONAL);
+  hb = Heartbeat_1_0::Mode::OPERATIONAL;
 
   /* Publish the heartbeat once/second */
   static unsigned long prev = 0;

--- a/examples/UAVCAN-Service-Client/UAVCAN-Service-Client.ino
+++ b/examples/UAVCAN-Service-Client/UAVCAN-Service-Client.ino
@@ -71,7 +71,11 @@ void setup()
 
   /* Request some coffee. */
   char const cmd_param[] = "I want a double espresso with cream";
-  ExecuteCommand_1_0::Request req(0xCAFE, reinterpret_cast<uint8_t const *>(cmd_param), sizeof(cmd_param));
+  ExecuteCommand_1_0::Request req;
+  req.data.command = 0xCAFE;
+  req.data.parameter_length = std::min(sizeof(cmd_param), uavcan_node_ExecuteCommand_1_0_Request_parameter_array_capacity());
+  std::copy(cmd_param, cmd_param + req.data.parameter_length, req.data.parameter);
+
   uavcan.request<ExecuteCommand_1_0::Request, ExecuteCommand_1_0::Response>(req, 27 /* remote node id */, onExecuteCommand_1_0_Response_Received);
 }
 

--- a/examples/UAVCAN-Service-Server/UAVCAN-Service-Server.ino
+++ b/examples/UAVCAN-Service-Server/UAVCAN-Service-Server.ino
@@ -114,12 +114,14 @@ void onExecuteCommand_1_0_Request_Received(CanardTransfer const & transfer, Ardu
 
   if (req.data.command == 0xCAFE)
   {
-    ExecuteCommand_1_0::Response rsp(ExecuteCommand_1_0::Response::Status::SUCCESS);
+    ExecuteCommand_1_0::Response rsp;
+    rsp = ExecuteCommand_1_0::Response::Status::SUCCESS;
     uavcan.respond(rsp, transfer.remote_node_id, transfer.transfer_id);
   }
   else
   {
-    ExecuteCommand_1_0::Response rsp(ExecuteCommand_1_0::Response::Status::NOT_AUTHORIZED);
+    ExecuteCommand_1_0::Response rsp;
+    rsp = ExecuteCommand_1_0::Response::Status::NOT_AUTHORIZED;
     uavcan.respond(rsp, transfer.remote_node_id, transfer.transfer_id);
   }
 }

--- a/extras/test/src/test_ExecuteCommand_ServiceClient.cpp
+++ b/extras/test/src/test_ExecuteCommand_ServiceClient.cpp
@@ -57,7 +57,11 @@ TEST_CASE("A '435.ExecuteCommand.1.0' request is sent to a server", "[execute-co
   ArduinoUAVCAN uavcan(util::LOCAL_NODE_ID, util::micros, transmitCanFrame);
 
   std::string const cmd_1_param = "I want a double espresso with cream";
-  ExecuteCommand_1_0::Request req_1(0xCAFE, reinterpret_cast<uint8_t const *>(cmd_1_param.c_str()), cmd_1_param.length());
+  ExecuteCommand_1_0::Request req_1;
+  req_1.data.command = 0xCAFE;
+  req_1.data.parameter_length = std::min(cmd_1_param.length(), uavcan_node_ExecuteCommand_1_0_Request_parameter_array_capacity());
+  std::copy(cmd_1_param.c_str(), cmd_1_param.c_str() + req_1.data.parameter_length, req_1.data.parameter);
+
 
   REQUIRE(uavcan.request<ExecuteCommand_1_0::Request, ExecuteCommand_1_0::Response>(req_1, REMOTE_NODE_ID, onExecuteCommand_1_0_Response_Received) == true);
   /* Transmit all the CAN frames. */
@@ -99,7 +103,10 @@ TEST_CASE("A '435.ExecuteCommand.1.0' request is sent to a server", "[execute-co
 
   /* Send a second request. */
   std::string const cmd_2_param = "I do not need coffee anymore";
-  ExecuteCommand_1_0::Request req_2(0xDEAD, reinterpret_cast<uint8_t const *>(cmd_2_param.c_str()), cmd_2_param.length());
+  ExecuteCommand_1_0::Request req_2;
+  req_2.data.command = 0xDEAD;
+  req_2.data.parameter_length = std::min(cmd_2_param.length(), uavcan_node_ExecuteCommand_1_0_Request_parameter_array_capacity());
+  std::copy(cmd_2_param.c_str(), cmd_2_param.c_str() + req_2.data.parameter_length, req_2.data.parameter);
 
   REQUIRE(uavcan.request<ExecuteCommand_1_0::Request, ExecuteCommand_1_0::Response>(req_2, REMOTE_NODE_ID, onExecuteCommand_1_0_Response_Received) == true);
   /* Transmit all the CAN frames. */

--- a/extras/test/src/test_ExecuteCommand_ServiceServer.cpp
+++ b/extras/test/src/test_ExecuteCommand_ServiceServer.cpp
@@ -55,7 +55,8 @@ void onExecuteCommand_1_0_Request_Received(CanardTransfer const & transfer, Ardu
   /* Deal with the command ... */
 
   /* ... and construct and send the response. */
-  ExecuteCommand_1_0::Response response(ExecuteCommand_1_0::Response::Status::NOT_AUTHORIZED);
+  ExecuteCommand_1_0::Response response;
+  response = ExecuteCommand_1_0::Response::Status::NOT_AUTHORIZED;
 
   uavcan.respond(response, transfer.remote_node_id, transfer.transfer_id);
 }

--- a/extras/test/src/test_ID.cpp
+++ b/extras/test/src/test_ID.cpp
@@ -58,7 +58,8 @@ TEST_CASE("A 'ID.1.0.uavcan' message is sent", "[id-01]")
 {
   ArduinoUAVCAN uavcan(util::LOCAL_NODE_ID, util::micros, transmitCanFrame);
 
-  ID_1_0<ID_PORT_ID> id(65);
+  ID_1_0<ID_PORT_ID> id;
+  id.data.value = 65;
   uavcan.publish(id);
   uavcan.transmitCanFrame();
   /*

--- a/extras/test/src/test_Version.cpp
+++ b/extras/test/src/test_Version.cpp
@@ -59,7 +59,9 @@ TEST_CASE("A 'Version.1.0.uavcan' message is sent", "[version-01]")
 {
   ArduinoUAVCAN uavcan(util::LOCAL_NODE_ID, util::micros, transmitCanFrame);
 
-  Version_1_0<VERSION_PORT_ID> version(0xCA, 0xFE);
+  Version_1_0<VERSION_PORT_ID> version;
+  version.data.major = 0xCA;
+  version.data.minor = 0xFE;
   uavcan.publish(version);
   uavcan.transmitCanFrame();
   /*

--- a/src/types/uavcan/node/ExecuteCommand.1.0.Request.cpp
+++ b/src/types/uavcan/node/ExecuteCommand.1.0.Request.cpp
@@ -46,13 +46,6 @@ Request::Request(Request const & other)
   memcpy(&data, &other.data, sizeof(data));
 }
 
-Request::Request(uint16_t const command, uint8_t const * parameter, size_t const parameter_length)
-{
-  data.command = command;
-  data.parameter_length = std::min(parameter_length, static_cast<size_t>(uavcan_node_ExecuteCommand_1_0_Request_parameter_array_capacity()));
-  std::copy(parameter, parameter + data.parameter_length, data.parameter);
-}
-
 /**************************************************************************************
  * PUBLIC MEMBER FUNCTIONS
  **************************************************************************************/

--- a/src/types/uavcan/node/ExecuteCommand.1.0.Request.cpp
+++ b/src/types/uavcan/node/ExecuteCommand.1.0.Request.cpp
@@ -36,6 +36,16 @@ constexpr CanardTransferKind Request::TRANSFER_KIND;
  * CTOR/DTOR
  **************************************************************************************/
 
+Request::Request()
+{
+  uavcan_node_ExecuteCommand_1_0_Request_init(&data);
+}
+
+Request::Request(Request const & other)
+{
+  memcpy(&data, &other.data, sizeof(data));
+}
+
 Request::Request(uint16_t const command, uint8_t const * parameter, size_t const parameter_length)
 {
   data.command = command;
@@ -49,10 +59,9 @@ Request::Request(uint16_t const command, uint8_t const * parameter, size_t const
 
 Request Request::create(CanardTransfer const & transfer)
 {
-  uavcan_node_ExecuteCommand_1_0_Request d;
-  uavcan_node_ExecuteCommand_1_0_Request_init(&d);
-  uavcan_node_ExecuteCommand_1_0_Request_deserialize(&d, 0, (uint8_t *)(transfer.payload), transfer.payload_size);
-  return Request(d.command, d.parameter, d.parameter_length);
+  Request r;
+  uavcan_node_ExecuteCommand_1_0_Request_deserialize(&r.data, 0, (uint8_t *)(transfer.payload), transfer.payload_size);
+  return r;
 }
 
 size_t Request::encode(uint8_t * payload) const

--- a/src/types/uavcan/node/ExecuteCommand.1.0.Request.h
+++ b/src/types/uavcan/node/ExecuteCommand.1.0.Request.h
@@ -40,11 +40,9 @@ public:
 
   Request();
   Request(Request const & other);
-  Request(uint16_t const command, uint8_t const * parameter, size_t const parameter_length);
 
   static Request create(CanardTransfer const & transfer);
   size_t encode(uint8_t * payload) const;
-
 };
 
 /**************************************************************************************

--- a/src/types/uavcan/node/ExecuteCommand.1.0.Request.h
+++ b/src/types/uavcan/node/ExecuteCommand.1.0.Request.h
@@ -38,6 +38,8 @@ public:
   static constexpr size_t             MAX_PAYLOAD_SIZE = uavcan_node_ExecuteCommand_1_0_Request_MAX_SERIALIZED_REPRESENTATION_SIZE_BYTES;
   static constexpr CanardTransferKind TRANSFER_KIND = CanardTransferKindRequest;
 
+  Request();
+  Request(Request const & other);
   Request(uint16_t const command, uint8_t const * parameter, size_t const parameter_length);
 
   static Request create(CanardTransfer const & transfer);

--- a/src/types/uavcan/node/ExecuteCommand.1.0.Response.cpp
+++ b/src/types/uavcan/node/ExecuteCommand.1.0.Response.cpp
@@ -42,18 +42,6 @@ Response::Response(Response const & other)
   memcpy(&data, &other.data, sizeof(data));
 }
 
-Response::Response(uint8_t const status)
-: data{status}
-{
-
-}
-
-Response::Response(Status const status)
-: Response{to_integer(status)}
-{
-
-}
-
 /**************************************************************************************
  * PUBLIC MEMBER FUNCTIONS
  **************************************************************************************/
@@ -69,6 +57,11 @@ size_t Response::encode(uint8_t * payload) const
 {
   size_t const offset = uavcan_node_ExecuteCommand_1_0_Response_serialize(&data, 0, payload);
   return (offset / 8);
+}
+
+void Response::operator = (Status const status)
+{
+  data.status = to_integer(status);
 }
 
 /**************************************************************************************

--- a/src/types/uavcan/node/ExecuteCommand.1.0.Response.cpp
+++ b/src/types/uavcan/node/ExecuteCommand.1.0.Response.cpp
@@ -32,6 +32,16 @@ constexpr CanardTransferKind Response::TRANSFER_KIND;
  * CTOR/DTOR
  **************************************************************************************/
 
+Response::Response()
+{
+  uavcan_node_ExecuteCommand_1_0_Response_init(&data);
+}
+
+Response::Response(Response const & other)
+{
+  memcpy(&data, &other.data, sizeof(data));
+}
+
 Response::Response(uint8_t const status)
 : data{status}
 {
@@ -50,10 +60,9 @@ Response::Response(Status const status)
 
 Response Response::create(CanardTransfer const & transfer)
 {
-  uavcan_node_ExecuteCommand_1_0_Response d;
-  uavcan_node_ExecuteCommand_1_0_Response_init(&d);
-  uavcan_node_ExecuteCommand_1_0_Response_deserialize(&d, 0, (uint8_t *)(transfer.payload), transfer.payload_size);
-  return Response(d.status);
+  Response r;
+  uavcan_node_ExecuteCommand_1_0_Response_deserialize(&r.data, 0, (uint8_t *)(transfer.payload), transfer.payload_size);
+  return r;
 }
 
 size_t Response::encode(uint8_t * payload) const

--- a/src/types/uavcan/node/ExecuteCommand.1.0.Response.h
+++ b/src/types/uavcan/node/ExecuteCommand.1.0.Response.h
@@ -49,6 +49,8 @@ public:
   static constexpr size_t             MAX_PAYLOAD_SIZE = uavcan_node_ExecuteCommand_1_0_Response_MAX_SERIALIZED_REPRESENTATION_SIZE_BYTES;
   static constexpr CanardTransferKind TRANSFER_KIND = CanardTransferKindResponse;
 
+  Response();
+  Response(Response const & other);
   Response(uint8_t const status);
   Response(Status const status);
 

--- a/src/types/uavcan/node/ExecuteCommand.1.0.Response.h
+++ b/src/types/uavcan/node/ExecuteCommand.1.0.Response.h
@@ -51,12 +51,11 @@ public:
 
   Response();
   Response(Response const & other);
-  Response(uint8_t const status);
-  Response(Status const status);
 
   static Response create(CanardTransfer const & transfer);
   size_t encode(uint8_t * payload) const;
 
+  void operator = (Status const status);
 };
 
 /**************************************************************************************

--- a/src/types/uavcan/node/Heartbeat.1.0.cpp
+++ b/src/types/uavcan/node/Heartbeat.1.0.cpp
@@ -25,6 +25,16 @@ constexpr CanardTransferKind Heartbeat_1_0::TRANSFER_KIND;
  * CTOR/DTOR
  **************************************************************************************/
 
+Heartbeat_1_0::Heartbeat_1_0()
+{
+  uavcan_node_Heartbeat_1_0_init(&data);
+}
+
+Heartbeat_1_0::Heartbeat_1_0(Heartbeat_1_0 const & other)
+{
+  memcpy(&data, &other.data, sizeof(data));
+}
+
 Heartbeat_1_0::Heartbeat_1_0(uint32_t const uptime, uint8_t const health, uint8_t const mode, uint32_t const vssc)
 : data{uptime, health, mode, vssc}
 {
@@ -43,10 +53,9 @@ Heartbeat_1_0::Heartbeat_1_0(uint32_t const uptime, Health const health, Mode co
 
 Heartbeat_1_0 Heartbeat_1_0::create(CanardTransfer const & transfer)
 {
-  uavcan_node_Heartbeat_1_0 d;
-  uavcan_node_Heartbeat_1_0_init(&d);
-  uavcan_node_Heartbeat_1_0_deserialize(&d, 0, (uint8_t *)(transfer.payload), transfer.payload_size);
-  return Heartbeat_1_0(d.uptime, d.health, d.mode, d.vendor_specific_status_code);
+  Heartbeat_1_0 h;
+  uavcan_node_Heartbeat_1_0_deserialize(&h.data, 0, (uint8_t *)(transfer.payload), transfer.payload_size);
+  return h;
 }
 
 size_t Heartbeat_1_0::encode(uint8_t * payload) const

--- a/src/types/uavcan/node/Heartbeat.1.0.cpp
+++ b/src/types/uavcan/node/Heartbeat.1.0.cpp
@@ -35,18 +35,6 @@ Heartbeat_1_0::Heartbeat_1_0(Heartbeat_1_0 const & other)
   memcpy(&data, &other.data, sizeof(data));
 }
 
-Heartbeat_1_0::Heartbeat_1_0(uint32_t const uptime, uint8_t const health, uint8_t const mode, uint32_t const vssc)
-: data{uptime, health, mode, vssc}
-{
-
-}
-
-Heartbeat_1_0::Heartbeat_1_0(uint32_t const uptime, Health const health, Mode const mode, uint32_t const vssc)
-: Heartbeat_1_0{uptime, to_integer(health), to_integer(mode), vssc}
-{
-
-}
-
 /**************************************************************************************
  * PUBLIC MEMBER FUNCTIONS
  **************************************************************************************/
@@ -62,4 +50,14 @@ size_t Heartbeat_1_0::encode(uint8_t * payload) const
 {
   size_t const offset = uavcan_node_Heartbeat_1_0_serialize(&data, 0, payload);
   return (offset / 8);
+}
+
+void Heartbeat_1_0::operator = (Health const health)
+{
+  data.health = to_integer(health);
+}
+
+void Heartbeat_1_0::operator = (Mode const mode)
+{
+  data.mode = to_integer(mode);
 }

--- a/src/types/uavcan/node/Heartbeat.1.0.h
+++ b/src/types/uavcan/node/Heartbeat.1.0.h
@@ -50,12 +50,12 @@ public:
 
   Heartbeat_1_0();
   Heartbeat_1_0(Heartbeat_1_0 const & other);
-  Heartbeat_1_0(uint32_t const uptime, uint8_t const health, uint8_t const mode, uint32_t const vssc);
-  Heartbeat_1_0(uint32_t const uptime, Health const health, Mode const mode, uint32_t const vssc);
 
   static Heartbeat_1_0 create(CanardTransfer const & transfer);
   size_t encode(uint8_t * payload) const;
 
+  void operator = (Health const health);
+  void operator = (Mode const mode);
 };
 
 #endif /* ARDUINO_TRANSFER_UAVCAN_NODE_HEARTBEAT_1_0_H_ */

--- a/src/types/uavcan/node/Heartbeat.1.0.h
+++ b/src/types/uavcan/node/Heartbeat.1.0.h
@@ -48,6 +48,8 @@ public:
   static constexpr size_t             MAX_PAYLOAD_SIZE = uavcan_node_Heartbeat_1_0_MAX_SERIALIZED_REPRESENTATION_SIZE_BYTES;
   static constexpr CanardTransferKind TRANSFER_KIND = CanardTransferKindMessage;
 
+  Heartbeat_1_0();
+  Heartbeat_1_0(Heartbeat_1_0 const & other);
   Heartbeat_1_0(uint32_t const uptime, uint8_t const health, uint8_t const mode, uint32_t const vssc);
   Heartbeat_1_0(uint32_t const uptime, Health const health, Mode const mode, uint32_t const vssc);
 

--- a/src/types/uavcan/node/ID.1.0.hpp
+++ b/src/types/uavcan/node/ID.1.0.hpp
@@ -34,7 +34,6 @@ public:
 
   ID_1_0();
   ID_1_0(ID_1_0 const & other);
-  ID_1_0(uint16_t const id);
 
   static ID_1_0 create(CanardTransfer const & transfer);
   size_t encode(uint8_t * payload) const;

--- a/src/types/uavcan/node/ID.1.0.hpp
+++ b/src/types/uavcan/node/ID.1.0.hpp
@@ -32,6 +32,8 @@ public:
   static constexpr size_t             MAX_PAYLOAD_SIZE = uavcan_node_ID_1_0_MAX_SERIALIZED_REPRESENTATION_SIZE_BYTES;
   static constexpr CanardTransferKind TRANSFER_KIND = CanardTransferKindMessage;
 
+  ID_1_0();
+  ID_1_0(ID_1_0 const & other);
   ID_1_0(uint16_t const id);
 
   static ID_1_0 create(CanardTransfer const & transfer);

--- a/src/types/uavcan/node/ID.1.0.ipp
+++ b/src/types/uavcan/node/ID.1.0.ipp
@@ -29,13 +29,6 @@ ID_1_0<ID>::ID_1_0(ID_1_0 const & other)
   memcpy(&data, &other.data, sizeof(data));
 }
 
-template <CanardPortID ID>
-ID_1_0<ID>::ID_1_0(uint16_t const id)
-: data{id}
-{
-
-}
-
 /**************************************************************************************
  * PUBLIC MEMBER FUNCTIONS
  **************************************************************************************/

--- a/src/types/uavcan/node/ID.1.0.ipp
+++ b/src/types/uavcan/node/ID.1.0.ipp
@@ -18,6 +18,18 @@ template <CanardPortID ID> constexpr CanardTransferKind ID_1_0<ID>::TRANSFER_KIN
  **************************************************************************************/
 
 template <CanardPortID ID>
+ID_1_0<ID>::ID_1_0()
+{
+  uavcan_node_ID_1_0_init(&data);
+}
+
+template <CanardPortID ID>
+ID_1_0<ID>::ID_1_0(ID_1_0 const & other)
+{
+  memcpy(&data, &other.data, sizeof(data));
+}
+
+template <CanardPortID ID>
 ID_1_0<ID>::ID_1_0(uint16_t const id)
 : data{id}
 {
@@ -31,10 +43,9 @@ ID_1_0<ID>::ID_1_0(uint16_t const id)
 template <CanardPortID ID>
 ID_1_0<ID> ID_1_0<ID>::create(CanardTransfer const & transfer)
 {
-  uavcan_node_ID_1_0 d;
-  uavcan_node_ID_1_0_init(&d);
-  uavcan_node_ID_1_0_deserialize(&d, 0, (uint8_t *)(transfer.payload), transfer.payload_size);
-  return ID_1_0<ID>(d.value);
+  ID_1_0<ID> i;
+  uavcan_node_ID_1_0_deserialize(&i.data, 0, (uint8_t *)(transfer.payload), transfer.payload_size);
+  return i;
 }
 
 template <CanardPortID ID>

--- a/src/types/uavcan/node/Version.1.0.hpp
+++ b/src/types/uavcan/node/Version.1.0.hpp
@@ -34,7 +34,6 @@ public:
 
   Version_1_0();
   Version_1_0(Version_1_0 const & other);
-  Version_1_0(uint8_t const major, uint8_t const minor);
 
   static Version_1_0 create(CanardTransfer const & transfer);
   size_t encode(uint8_t * payload) const;

--- a/src/types/uavcan/node/Version.1.0.hpp
+++ b/src/types/uavcan/node/Version.1.0.hpp
@@ -32,6 +32,8 @@ public:
   static constexpr size_t             MAX_PAYLOAD_SIZE = uavcan_node_Version_1_0_MAX_SERIALIZED_REPRESENTATION_SIZE_BYTES;
   static constexpr CanardTransferKind TRANSFER_KIND = CanardTransferKindMessage;
 
+  Version_1_0();
+  Version_1_0(Version_1_0 const & other);
   Version_1_0(uint8_t const major, uint8_t const minor);
 
   static Version_1_0 create(CanardTransfer const & transfer);

--- a/src/types/uavcan/node/Version.1.0.ipp
+++ b/src/types/uavcan/node/Version.1.0.ipp
@@ -18,6 +18,18 @@ template <CanardPortID ID> constexpr CanardTransferKind Version_1_0<ID>::TRANSFE
  **************************************************************************************/
 
 template <CanardPortID ID>
+Version_1_0<ID>::Version_1_0()
+{
+  uavcan_node_Version_1_0_init(&data);
+}
+
+template <CanardPortID ID>
+Version_1_0<ID>::Version_1_0(Version_1_0 const & other)
+{
+  memcpy(&data, &other.data, sizeof(data));
+}
+
+template <CanardPortID ID>
 Version_1_0<ID>::Version_1_0(uint8_t const major, uint8_t const minor)
 : data{major, minor}
 {
@@ -31,10 +43,9 @@ Version_1_0<ID>::Version_1_0(uint8_t const major, uint8_t const minor)
 template <CanardPortID ID>
 Version_1_0<ID> Version_1_0<ID>::create(CanardTransfer const & transfer)
 {
-  uavcan_node_Version_1_0 d;
-  uavcan_node_Version_1_0_init(&d);
-  uavcan_node_Version_1_0_deserialize(&d, 0, (uint8_t *)(transfer.payload), transfer.payload_size);
-  return Version_1_0<ID>(d.major, d.minor);
+  Version_1_0<ID> v;
+  uavcan_node_Version_1_0_deserialize(&v.data, 0, (uint8_t *)(transfer.payload), transfer.payload_size);
+  return v;
 }
 
 template <CanardPortID ID>

--- a/src/types/uavcan/node/Version.1.0.ipp
+++ b/src/types/uavcan/node/Version.1.0.ipp
@@ -29,13 +29,6 @@ Version_1_0<ID>::Version_1_0(Version_1_0 const & other)
   memcpy(&data, &other.data, sizeof(data));
 }
 
-template <CanardPortID ID>
-Version_1_0<ID>::Version_1_0(uint8_t const major, uint8_t const minor)
-: data{major, minor}
-{
-
-}
-
 /**************************************************************************************
  * PUBLIC MEMBER FUNCTIONS
  **************************************************************************************/


### PR DESCRIPTION
Only provide default-ctor and copy-ctor, access data via `public struct data` and provide convenient assignment functions for enum classes where feasible.