### PR TITLE
Bugfix: Replace byte array with std::array to allow zero-sized arrays

### DIFF
--- a/src/ArduinoUAVCAN.ipp
+++ b/src/ArduinoUAVCAN.ipp
@@ -20,11 +20,12 @@ bool ArduinoUAVCAN::publish(T_MSG const & msg)
 {
   static_assert(T_MSG::TRANSFER_KIND == CanardTransferKindMessage, "ArduinoUAVCAN::publish API only works with CanardTransferKindMessage");
 
-  uint8_t payload_buf[T_MSG::MAX_PAYLOAD_SIZE] = {0};
-  size_t const payload_size = msg.encode(payload_buf);
+  std::array<uint8_t, T_MSG::MAX_PAYLOAD_SIZE> payload_buf;
+  payload_buf.fill(0);
+  size_t const payload_size = msg.encode(payload_buf.data());
   CanardTransferID const transfer_id = getNextTransferId(T_MSG::PORT_ID);
 
-  return enqeueTransfer(CANARD_NODE_ID_UNSET, T_MSG::TRANSFER_KIND, T_MSG::PORT_ID, payload_size, payload_buf, transfer_id);
+  return enqeueTransfer(CANARD_NODE_ID_UNSET, T_MSG::TRANSFER_KIND, T_MSG::PORT_ID, payload_size, payload_buf.data(), transfer_id);
 }
 
 template <typename T_RSP>
@@ -32,10 +33,11 @@ bool ArduinoUAVCAN::respond(T_RSP const & rsp, CanardNodeID const remote_node_id
 {
   static_assert(T_RSP::TRANSFER_KIND == CanardTransferKindResponse, "ArduinoUAVCAN::respond API only works with CanardTransferKindResponse");
 
-  uint8_t payload_buf[T_RSP::MAX_PAYLOAD_SIZE] = {0};
-  size_t const payload_size = rsp.encode(payload_buf);
+  std::array<uint8_t, T_RSP::MAX_PAYLOAD_SIZE> payload_buf;
+  payload_buf.fill(0);
+  size_t const payload_size = rsp.encode(payload_buf.data());
 
-  return enqeueTransfer(remote_node_id, T_RSP::TRANSFER_KIND, T_RSP::PORT_ID, payload_size, payload_buf, transfer_id);
+  return enqeueTransfer(remote_node_id, T_RSP::TRANSFER_KIND, T_RSP::PORT_ID, payload_size, payload_buf.data(), transfer_id);
 }
 
 template <typename T_REQ, typename T_RSP>
@@ -44,11 +46,12 @@ bool ArduinoUAVCAN::request(T_REQ const & req, CanardNodeID const remote_node_id
   static_assert(T_REQ::TRANSFER_KIND == CanardTransferKindRequest,  "ArduinoUAVCAN::request<T_REQ, T_RSP> API - T_REQ != CanardTransferKindRequest");
   static_assert(T_RSP::TRANSFER_KIND == CanardTransferKindResponse, "ArduinoUAVCAN::request<T_REQ, T_RSP> API - T_RSP != CanardTransferKindResponse");
 
-  uint8_t payload_buf[T_REQ::MAX_PAYLOAD_SIZE] = {0};
-  size_t const payload_size = req.encode(payload_buf);
+  std::array<uint8_t, T_REQ::MAX_PAYLOAD_SIZE> payload_buf;
+  payload_buf.fill(0);
+  size_t const payload_size = req.encode(payload_buf.data());
   CanardTransferID const transfer_id = getNextTransferId(T_REQ::PORT_ID);
 
-  if (!enqeueTransfer(remote_node_id, T_REQ::TRANSFER_KIND, T_REQ::PORT_ID, payload_size, payload_buf, transfer_id))
+  if (!enqeueTransfer(remote_node_id, T_REQ::TRANSFER_KIND, T_REQ::PORT_ID, payload_size, payload_buf.data(), transfer_id))
     return false;
 
   return subscribe(T_RSP::TRANSFER_KIND, T_RSP::PORT_ID, T_RSP::MAX_PAYLOAD_SIZE, func);


### PR DESCRIPTION
`std::array` allows for zero-sized arrays. This can happen if a UAVCAN message has no payload.