### PR TITLE
Update to using the new compilation testing actions repositories in CI workflows

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Compile examples
-        uses: arduino/actions/libraries/compile-examples@master
+        uses: arduino/compile-sketches@main
         with:
           fqbn: ${{ matrix.fqbn }}
           libraries: ${{ env.LIBRARIES }}
@@ -45,5 +45,5 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v1
         with:
-          name: size-deltas-reports
-          path: size-deltas-reports
+          name: sketches-reports
+          path: sketches-reports

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # See: https://github.com/arduino/actions/blob/master/libraries/report-size-deltas/README.md
+      # See: https://github.com/arduino/report-size-deltas/README.md
       - name: Comment size deltas reports to PRs
-        uses: arduino/actions/libraries/report-size-deltas@master
+        uses: arduino/report-size-deltas@main


### PR DESCRIPTION
The `arduino/actions` repository that previously hosted the GitHub Actions actions was for development of them in their experimental stage. The actions have now progressed to the point where they can have dedicated repositories. All further development work will be done in the dedicated repository.

The default branch name of the new repositories is `main`, as opposed the the `master` used in the experimental repository.

The versions of the actions in the dedicated repository now using `sketches-reports` instead of `size-deltas-reports` as the default sketches reports path and workflow name, so it was necessary to change the names specified to the `actions/upload-artifact` action's inputs to reflect this change.

---
Demonstration PR using the new workflows (including with the scheduled workflow in the default branch, as required by GitHub Actions): https://github.com/per1234/107-Arduino-UAVCAN/pull/1