### PR TITLE
Use arduino/cpp-test-action action in Unit Test CI workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,41 +20,25 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      BUILD_PATH: ${{ github.workspace }}/extras/test/build
+      COVERAGE_DATA_PATH: extras/coverage-data/coverage.info
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install valgrind
-        run: sudo apt-get --assume-yes install valgrind
-
-      - name: Run unit tests
-        run: |
-          mkdir "$BUILD_PATH"
-          cd "$BUILD_PATH"
-          # Generate makefile
-          cmake ..
-          # Compile tests
-          make
-          # Run tests and check for memory leaks
-          valgrind --leak-check=yes --error-exitcode=1 bin/test-107-Arduino-UAVCAN
-
-      - name: Install lcov
-        run: sudo apt-get --assume-yes install lcov
-
-      - name: Report code coverage
-        run: |
-          cd "$BUILD_PATH"
-          lcov --directory . --capture --output-file coverage.info
-          # Remove external files from coverage data
-          lcov --quiet --remove coverage.info '*/extras/test/*' '/usr/*' '*/src/libcanard/*' '*/src/o1heap/*' --output-file coverage.info
-          # Print coverage report in the workflow log
-          lcov --list coverage.info
+      - uses: arduino/cpp-test-action@main
+        with:
+          runtime-path: extras/test/build/bin/test-107-Arduino-UAVCAN
+          coverage-exclude-paths: |
+            - '*/extras/test/*'
+            - '/usr/*'
+            - '*/src/libcanard/*'
+            - '*/src/o1heap/*'
+          coverage-data-path: ${{ env.COVERAGE_DATA_PATH }}
 
       # See: https://github.com/codecov/codecov-action/blob/master/README.md
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1
         with:
-          file: ${{ env.BUILD_PATH }}/coverage.info
+          file: ${{ env.COVERAGE_DATA_PATH }}
           fail_ci_if_error: true


### PR DESCRIPTION
This simplifies the workflow and moves the maintenance of the commands used for the testing procedure to a centralized location.