### PR TITLE
Protect libcanard API calls within critical sections to prevent race conditions.

### DIFF
--- a/extras/test/CMakeLists.txt
+++ b/extras/test/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TEST_SRCS
   ../../src/types/uavcan/node/ExecuteCommand.1.0.Request.cpp
   ../../src/types/uavcan/node/ExecuteCommand.1.0.Response.cpp
   ../../src/types/uavcan/node/Heartbeat.1.0.cpp
+  ../../src/utility/CritSec-host.cpp
   ../../src/ArduinoO1Heap.cpp
   ../../src/ArduinoUAVCAN.cpp
 )

--- a/src/ArduinoO1Heap.cpp
+++ b/src/ArduinoO1Heap.cpp
@@ -11,20 +11,12 @@
 
 #include "ArduinoO1Heap.h"
 
-#ifndef HOST
-  #include "utility/CritSec.h"
-#endif
-
 /**************************************************************************************
  * CTOR/DTOR
  **************************************************************************************/
 
 ArduinoO1Heap::ArduinoO1Heap()
-#ifndef HOST
-: _o1heap_ins{o1heapInit(_base, HEAP_SIZE, crit_sec_enter, crit_sec_leave)}
-#else
 : _o1heap_ins{o1heapInit(_base, HEAP_SIZE, nullptr, nullptr)}
-#endif
 {
 
 }

--- a/src/ArduinoUAVCAN.cpp
+++ b/src/ArduinoUAVCAN.cpp
@@ -31,6 +31,8 @@ ArduinoUAVCAN::ArduinoUAVCAN(uint8_t const node_id,
 
 void ArduinoUAVCAN::onCanFrameReceived(CanardFrame const & frame)
 {
+  LockGuard lock;
+
   CanardTransfer transfer;
   int8_t const result = canardRxAccept(&_canard_ins,
                                        &frame,
@@ -59,6 +61,8 @@ void ArduinoUAVCAN::onCanFrameReceived(CanardFrame const & frame)
 
 bool ArduinoUAVCAN::transmitCanFrame()
 {
+  LockGuard lock;
+
   if (!_transmit_func)
     return false;
 

--- a/src/ArduinoUAVCAN.h
+++ b/src/ArduinoUAVCAN.h
@@ -26,6 +26,7 @@
 #include "libcanard/canard.h"
 
 #include "utility/convert.hpp"
+#include "utility/LockGuard.h"
 
 /**************************************************************************************
  * TYPEDEF

--- a/src/ArduinoUAVCAN.ipp
+++ b/src/ArduinoUAVCAN.ipp
@@ -12,12 +12,16 @@
 template <typename T>
 bool ArduinoUAVCAN::subscribe(OnTransferReceivedFunc func)
 {
+  LockGuard lock;
+
   return subscribe(T::TRANSFER_KIND, T::PORT_ID, T::MAX_PAYLOAD_SIZE, func);
 }
 
 template <typename T_MSG>
 bool ArduinoUAVCAN::publish(T_MSG const & msg)
 {
+  LockGuard lock;
+
   static_assert(T_MSG::TRANSFER_KIND == CanardTransferKindMessage, "ArduinoUAVCAN::publish API only works with CanardTransferKindMessage");
 
   std::array<uint8_t, T_MSG::MAX_PAYLOAD_SIZE> payload_buf;
@@ -31,6 +35,8 @@ bool ArduinoUAVCAN::publish(T_MSG const & msg)
 template <typename T_RSP>
 bool ArduinoUAVCAN::respond(T_RSP const & rsp, CanardNodeID const remote_node_id, CanardTransferID const transfer_id)
 {
+  LockGuard lock;
+
   static_assert(T_RSP::TRANSFER_KIND == CanardTransferKindResponse, "ArduinoUAVCAN::respond API only works with CanardTransferKindResponse");
 
   std::array<uint8_t, T_RSP::MAX_PAYLOAD_SIZE> payload_buf;
@@ -43,6 +49,8 @@ bool ArduinoUAVCAN::respond(T_RSP const & rsp, CanardNodeID const remote_node_id
 template <typename T_REQ, typename T_RSP>
 bool ArduinoUAVCAN::request(T_REQ const & req, CanardNodeID const remote_node_id, OnTransferReceivedFunc func)
 {
+  LockGuard lock;
+
   static_assert(T_REQ::TRANSFER_KIND == CanardTransferKindRequest,  "ArduinoUAVCAN::request<T_REQ, T_RSP> API - T_REQ != CanardTransferKindRequest");
   static_assert(T_RSP::TRANSFER_KIND == CanardTransferKindResponse, "ArduinoUAVCAN::request<T_REQ, T_RSP> API - T_RSP != CanardTransferKindResponse");
 

--- a/src/utility/CritSec-host.cpp
+++ b/src/utility/CritSec-host.cpp
@@ -1,0 +1,38 @@
+/**
+ * This software is distributed under the terms of the MIT License.
+ * Copyright (c) 2020 LXRobotics.
+ * Author: Alexander Entinger <alexander.entinger@lxrobotics.com>
+ * Contributors: https://github.com/107-systems/107-Arduino-UAVCAN/graphs/contributors.
+ */
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include "CritSec.h"
+
+#ifdef HOST
+
+#include <mutex>
+
+/**************************************************************************************
+ * GLOBAL VARIABLES
+ **************************************************************************************/
+
+std::mutex mtx;
+
+/**************************************************************************************
+ * FUNCTION DEFINITION
+ **************************************************************************************/
+
+extern "C" void crit_sec_enter()
+{
+  mtx.lock();
+}
+
+extern "C" void crit_sec_leave()
+{
+  mtx.unlock();
+}
+
+#endif /* HOST */

--- a/src/utility/CritSec.h
+++ b/src/utility/CritSec.h
@@ -16,8 +16,8 @@ extern "C" {
  * FUNCTION DECLARATION
  **************************************************************************************/
 
-void crit_sec_enter() __attribute__((always_inline));
-void crit_sec_leave() __attribute__((always_inline));
+void crit_sec_enter();
+void crit_sec_leave();
 
 #ifdef __cplusplus
 }

--- a/src/utility/LockGuard.h
+++ b/src/utility/LockGuard.h
@@ -1,0 +1,28 @@
+/**
+ * This software is distributed under the terms of the MIT License.
+ * Copyright (c) 2020 LXRobotics.
+ * Author: Alexander Entinger <alexander.entinger@lxrobotics.com>
+ * Contributors: https://github.com/107-systems/107-Arduino-UAVCAN/graphs/contributors.
+ */
+
+#ifndef ARDUINO_LOCK_GUARD_H_
+#define ARDUINO_LOCK_GUARD_H_
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include "CritSec.h"
+
+/**************************************************************************************
+ * CLASS DECLARATION
+ **************************************************************************************/
+
+class LockGuard
+{
+public:
+   LockGuard() { crit_sec_enter(); }
+  ~LockGuard() { crit_sec_leave(); }
+};
+
+#endif /* ARDUINO_LOCK_GUARD_H_ */


### PR DESCRIPTION
This fixes #55.