### PR TITLE
Add CI workflow to do Arduino project-specific linting

### DIFF
--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -1,0 +1,26 @@
+name: Arduino Lint
+on:
+  push:
+  pull_request:
+  # Scheduled trigger checks for breakage caused by new rules added to Arduino Lint
+  schedule:
+    # run every Saturday at 3 AM UTC
+    - cron: "0 3 * * 6"
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+  # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Arduino Lint
+        uses: arduino/arduino-lint-action@v1
+        with:
+          project-type: library
+          library-manager: update

--- a/.github/workflows/extra-library-checks.yml
+++ b/.github/workflows/extra-library-checks.yml
@@ -25,27 +25,8 @@ jobs:
           # Checkout the latest tag
           git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
 
-      # See: https://github.com/per1234/arduino-ci-script#check_library_structure-basepath-depth
-      - name: Check library structure
-        run: |
-          source "${ARDUINO_CI_SCRIPT_FOLDER}/arduino-ci-script.sh"
-          # https://github.com/per1234/arduino-ci-script#check_library_structure-basepath-depth
-          check_library_structure "$GITHUB_WORKSPACE"
-
-      # See: https://github.com/per1234/arduino-ci-script#check_library_properties-searchpath-maximumsearchdepth
-      - name: Check library.properties
-        run: |
-          source "${ARDUINO_CI_SCRIPT_FOLDER}/arduino-ci-script.sh"
-          check_library_properties "$GITHUB_WORKSPACE"
-
       # See: https://github.com/per1234/arduino-ci-script#check_keywords_txt-searchpath-maximumsearchdepth
       - name: Check keywords.txt
         run: |
           source "${ARDUINO_CI_SCRIPT_FOLDER}/arduino-ci-script.sh"
           check_keywords_txt "$GITHUB_WORKSPACE"
-
-      # See: https://github.com/per1234/arduino-ci-script#check_library_manager_compliance-librarypath
-      - name: Check Library Manager compliance
-        run: |
-          source "${ARDUINO_CI_SCRIPT_FOLDER}/arduino-ci-script.sh"
-          check_library_manager_compliance "$GITHUB_WORKSPACE"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Unit Tests](https://github.com/107-systems/107-Arduino-UAVCAN/workflows/Unit%20Tests/badge.svg)](https://github.com/107-systems/107-Arduino-UAVCAN/actions?workflow=Unit+Tests)
 [![codecov](https://codecov.io/gh/107-systems/107-Arduino-UAVCAN/branch/master/graph/badge.svg)](https://codecov.io/gh/107-systems/107-Arduino-UAVCAN)
 [![Compile Examples](https://github.com/107-systems/107-Arduino-UAVCAN/workflows/Compile%20Examples/badge.svg)](https://github.com/107-systems/107-Arduino-UAVCAN/actions?workflow=Compile+Examples)
+[![Arduino Lint](https://github.com/107-systems/107-Arduino-UAVCAN/workflows/Arduino%20Lint/badge.svg)](https://github.com/107-systems/107-Arduino-UAVCAN/actions?workflow=Arduino+Lint)
 [![Extra Library Checks](https://github.com/107-systems/107-Arduino-UAVCAN/workflows/Extra%20Library%20Checks/badge.svg)](https://github.com/107-systems/107-Arduino-UAVCAN/actions?workflow=Extra+Library+Checks)
 [![General Formatting Checks](https://github.com/107-systems/107-Arduino-UAVCAN/workflows/General%20Formatting%20Checks/badge.svg)](https://github.com/107-systems/107-Arduino-UAVCAN/actions?workflow=General+Formatting+Checks)
 [![Spell Check](https://github.com/107-systems/107-Arduino-UAVCAN/workflows/Spell%20Check/badge.svg)](https://github.com/107-systems/107-Arduino-UAVCAN/actions?workflow=Spell+Check)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/107-systems/107-Arduino-UAVCAN/branch/master/graph/badge.svg)](https://codecov.io/gh/107-systems/107-Arduino-UAVCAN)
 [![Compile Examples](https://github.com/107-systems/107-Arduino-UAVCAN/workflows/Compile%20Examples/badge.svg)](https://github.com/107-systems/107-Arduino-UAVCAN/actions?workflow=Compile+Examples)
 [![Arduino Lint](https://github.com/107-systems/107-Arduino-UAVCAN/workflows/Arduino%20Lint/badge.svg)](https://github.com/107-systems/107-Arduino-UAVCAN/actions?workflow=Arduino+Lint)
-[![Extra Library Checks](https://github.com/107-systems/107-Arduino-UAVCAN/workflows/Extra%20Library%20Checks/badge.svg)](https://github.com/107-systems/107-Arduino-UAVCAN/actions?workflow=Extra+Library+Checks)
+[![keywords.txt Checks](https://github.com/107-systems/107-Arduino-UAVCAN/workflows/Extra%20Library%20Checks/badge.svg)](https://github.com/107-systems/107-Arduino-UAVCAN/actions?workflow=Extra+Library+Checks)
 [![General Formatting Checks](https://github.com/107-systems/107-Arduino-UAVCAN/workflows/General%20Formatting%20Checks/badge.svg)](https://github.com/107-systems/107-Arduino-UAVCAN/actions?workflow=General+Formatting+Checks)
 [![Spell Check](https://github.com/107-systems/107-Arduino-UAVCAN/workflows/Spell%20Check/badge.svg)](https://github.com/107-systems/107-Arduino-UAVCAN/actions?workflow=Spell+Check)
 


### PR DESCRIPTION
On every push or pull request, run [Arduino Lint](https://github.com/arduino/arduino-lint) to check for common problems not related to the project code.