### PR TITLE
Compile examples for an ESP32 board in the CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -36,10 +36,18 @@ jobs:
           - fqbn: "arduino:mbed:nano33ble"
             platforms: |
               - name: "arduino:mbed"
+          - fqbn: "esp32:esp32:esp32"
+            platforms: |
+              - name: "esp32:esp32"
+                source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Install ESP32 platform dependencies
+        if: startsWith(matrix.board.fqbn, 'esp32:esp32')
+        run: pip3 install pyserial
 
       - name: Compile examples
         uses: arduino/compile-sketches@main

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -23,11 +23,19 @@ jobs:
       fail-fast: false
 
       matrix:
-        fqbn:
-          - "arduino:samd:mkrvidor4000"
-          - "arduino:mbed:envie_m7"
-          - "arduino:mbed:envie_m4"
-          - "arduino:mbed:nano33ble"
+        board:
+          - fqbn: "arduino:samd:mkrvidor4000"
+            platforms: |
+              - name: "arduino:samd"
+          - fqbn: "arduino:mbed:envie_m7"
+            platforms: |
+              - name: "arduino:mbed"
+          - fqbn: "arduino:mbed:envie_m4"
+            platforms: |
+              - name: "arduino:mbed"
+          - fqbn: "arduino:mbed:nano33ble"
+            platforms: |
+              - name: "arduino:mbed"
 
     steps:
       - name: Checkout
@@ -36,7 +44,8 @@ jobs:
       - name: Compile examples
         uses: arduino/compile-sketches@main
         with:
-          fqbn: ${{ matrix.fqbn }}
+          fqbn: ${{ matrix.board.fqbn }}
+          platforms: ${{ matrix.board.platforms }}
           libraries: ${{ env.LIBRARIES }}
           enable-size-deltas-report: true
 


### PR DESCRIPTION
The `esp32:esp32` package is unique in that it doesn't provide all the necessary dependencies of the platform. For this
reason, an additional conditional step must be added to the workflow to install this dependency during the matrix job
for the ESP32 board.