### PR TITLE
Fixing build issues when using this library with ESP32.

### DIFF
--- a/examples/UAVCAN-Blink/UAVCAN-Blink.ino
+++ b/examples/UAVCAN-Blink/UAVCAN-Blink.ino
@@ -30,6 +30,10 @@ static int const MKRCAN_MCP2515_CS_PIN  = 3;
 static int const MKRCAN_MCP2515_INT_PIN = 7;
 static CanardPortID const BIT_PORT_ID   = 1620U;
 
+#if defined(ESP32)
+static int const LED_BUILTIN = 2;
+#endif
+
 /**************************************************************************************
  * FUNCTION DECLARATION
  **************************************************************************************/

--- a/examples/UAVCAN-Heartbeat-Subscribe/UAVCAN-Heartbeat-Subscribe.ino
+++ b/examples/UAVCAN-Heartbeat-Subscribe/UAVCAN-Heartbeat-Subscribe.ino
@@ -114,7 +114,7 @@ void onHeartbeat_1_0_Received(CanardTransfer const & transfer, ArduinoUAVCAN & /
   char msg[64];
   snprintf(msg, 64,
            "ID %02X, Uptime = %d, Health = %d, Mode = %d, VSSC = %d",
-           transfer.remote_node_id, hb.data.uptime, hb.data.health, hb.data.mode, hb.data.vendor_specific_status_code);
+           transfer.remote_node_id, hb.data.uptime, hb.data.health.value, hb.data.mode.value, hb.data.vendor_specific_status_code);
 
   Serial.println(msg);
 }

--- a/src/utility/CritSec-esp32.c
+++ b/src/utility/CritSec-esp32.c
@@ -1,0 +1,38 @@
+/**
+ * This software is distributed under the terms of the MIT License.
+ * Copyright (c) 2020 LXRobotics.
+ * Author: Alexander Entinger <alexander.entinger@lxrobotics.com>
+ * Contributors: https://github.com/107-systems/107-Arduino-UAVCAN/graphs/contributors.
+ */
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include "CritSec.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+
+#include <Arduino.h>
+
+/**************************************************************************************
+ * GLOBAL VARIABLES
+ **************************************************************************************/
+
+static portMUX_TYPE mtx = portMUX_INITIALIZER_UNLOCKED;
+
+/**************************************************************************************
+ * FUNCTION DEFINITION
+ **************************************************************************************/
+
+void crit_sec_enter()
+{
+  portENTER_CRITICAL(&mtx);
+}
+
+void crit_sec_leave()
+{
+  portEXIT_CRITICAL(&mtx);
+}
+
+#endif /* ARDUINO_ARCH_ESP32 */

--- a/src/utility/convert.hpp
+++ b/src/utility/convert.hpp
@@ -18,7 +18,11 @@
  * NAMESPACE
  **************************************************************************************/
 
-namespace arduino::_107_::uavcan
+namespace arduino
+{
+namespace _107_
+{
+namespace uavcan
 {
 
 /**************************************************************************************
@@ -35,6 +39,8 @@ constexpr auto to_integer(Enumeration const value) -> typename std::underlying_t
  * NAMESPACE
  **************************************************************************************/
 
-} /* arduino::_107_::uavcan */
+} /* uavcan */
+} /* _107_ */
+} /* arduino */
 
 #endif /* ARDUINO_UAVCAN_UTILITY_COVERT_HPP_ */


### PR DESCRIPTION
ESP32 Core does not support C++14, ergo no nested namespaces are supported. This commit changes the code to conventional namespaces therefore allowing CI to pass for ESP32.

This fixes #69.