### PR TITLE
Workaround for erroneous macro expansion (isfinite) on ESP32

### DIFF
--- a/src/types/reg/drone/physics/kinematics/cartesian/PointVar_0_1.h
+++ b/src/types/reg/drone/physics/kinematics/cartesian/PointVar_0_1.h
@@ -27,6 +27,8 @@
 #include <types/reg/drone/physics/kinematics/cartesian/Point_0_1.h>
 #include <stdlib.h>
 #include <string.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/physics/kinematics/cartesian/PointVar.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -133,7 +135,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PointVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat0_ = obj->covariance_urt[0];
-            if (isfinite(_sat0_))
+            if (std::isfinite(_sat0_))
             {
                 if (_sat0_ < ((float) -65504.0))
                 {
@@ -155,7 +157,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PointVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat1_ = obj->covariance_urt[1];
-            if (isfinite(_sat1_))
+            if (std::isfinite(_sat1_))
             {
                 if (_sat1_ < ((float) -65504.0))
                 {
@@ -177,7 +179,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PointVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat2_ = obj->covariance_urt[2];
-            if (isfinite(_sat2_))
+            if (std::isfinite(_sat2_))
             {
                 if (_sat2_ < ((float) -65504.0))
                 {
@@ -199,7 +201,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PointVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat3_ = obj->covariance_urt[3];
-            if (isfinite(_sat3_))
+            if (std::isfinite(_sat3_))
             {
                 if (_sat3_ < ((float) -65504.0))
                 {
@@ -221,7 +223,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PointVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat4_ = obj->covariance_urt[4];
-            if (isfinite(_sat4_))
+            if (std::isfinite(_sat4_))
             {
                 if (_sat4_ < ((float) -65504.0))
                 {
@@ -243,7 +245,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PointVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat5_ = obj->covariance_urt[5];
-            if (isfinite(_sat5_))
+            if (std::isfinite(_sat5_))
             {
                 if (_sat5_ < ((float) -65504.0))
                 {

--- a/src/types/reg/drone/physics/kinematics/cartesian/PoseVar_0_1.h
+++ b/src/types/reg/drone/physics/kinematics/cartesian/PoseVar_0_1.h
@@ -27,6 +27,8 @@
 #include <types/reg/drone/physics/kinematics/cartesian/Pose_0_1.h>
 #include <stdlib.h>
 #include <string.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/physics/kinematics/cartesian/PoseVar.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -133,7 +135,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat0_ = obj->covariance_urt[0];
-            if (isfinite(_sat0_))
+            if (std::isfinite(_sat0_))
             {
                 if (_sat0_ < ((float) -65504.0))
                 {
@@ -155,7 +157,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat1_ = obj->covariance_urt[1];
-            if (isfinite(_sat1_))
+            if (std::isfinite(_sat1_))
             {
                 if (_sat1_ < ((float) -65504.0))
                 {
@@ -177,7 +179,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat2_ = obj->covariance_urt[2];
-            if (isfinite(_sat2_))
+            if (std::isfinite(_sat2_))
             {
                 if (_sat2_ < ((float) -65504.0))
                 {
@@ -199,7 +201,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat3_ = obj->covariance_urt[3];
-            if (isfinite(_sat3_))
+            if (std::isfinite(_sat3_))
             {
                 if (_sat3_ < ((float) -65504.0))
                 {
@@ -221,7 +223,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat4_ = obj->covariance_urt[4];
-            if (isfinite(_sat4_))
+            if (std::isfinite(_sat4_))
             {
                 if (_sat4_ < ((float) -65504.0))
                 {
@@ -243,7 +245,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat5_ = obj->covariance_urt[5];
-            if (isfinite(_sat5_))
+            if (std::isfinite(_sat5_))
             {
                 if (_sat5_ < ((float) -65504.0))
                 {
@@ -265,7 +267,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat6_ = obj->covariance_urt[6];
-            if (isfinite(_sat6_))
+            if (std::isfinite(_sat6_))
             {
                 if (_sat6_ < ((float) -65504.0))
                 {
@@ -287,7 +289,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat7_ = obj->covariance_urt[7];
-            if (isfinite(_sat7_))
+            if (std::isfinite(_sat7_))
             {
                 if (_sat7_ < ((float) -65504.0))
                 {
@@ -309,7 +311,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat8_ = obj->covariance_urt[8];
-            if (isfinite(_sat8_))
+            if (std::isfinite(_sat8_))
             {
                 if (_sat8_ < ((float) -65504.0))
                 {
@@ -331,7 +333,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat9_ = obj->covariance_urt[9];
-            if (isfinite(_sat9_))
+            if (std::isfinite(_sat9_))
             {
                 if (_sat9_ < ((float) -65504.0))
                 {
@@ -353,7 +355,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat10_ = obj->covariance_urt[10];
-            if (isfinite(_sat10_))
+            if (std::isfinite(_sat10_))
             {
                 if (_sat10_ < ((float) -65504.0))
                 {
@@ -375,7 +377,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat11_ = obj->covariance_urt[11];
-            if (isfinite(_sat11_))
+            if (std::isfinite(_sat11_))
             {
                 if (_sat11_ < ((float) -65504.0))
                 {
@@ -397,7 +399,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat12_ = obj->covariance_urt[12];
-            if (isfinite(_sat12_))
+            if (std::isfinite(_sat12_))
             {
                 if (_sat12_ < ((float) -65504.0))
                 {
@@ -419,7 +421,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat13_ = obj->covariance_urt[13];
-            if (isfinite(_sat13_))
+            if (std::isfinite(_sat13_))
             {
                 if (_sat13_ < ((float) -65504.0))
                 {
@@ -441,7 +443,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat14_ = obj->covariance_urt[14];
-            if (isfinite(_sat14_))
+            if (std::isfinite(_sat14_))
             {
                 if (_sat14_ < ((float) -65504.0))
                 {
@@ -463,7 +465,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat15_ = obj->covariance_urt[15];
-            if (isfinite(_sat15_))
+            if (std::isfinite(_sat15_))
             {
                 if (_sat15_ < ((float) -65504.0))
                 {
@@ -485,7 +487,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat16_ = obj->covariance_urt[16];
-            if (isfinite(_sat16_))
+            if (std::isfinite(_sat16_))
             {
                 if (_sat16_ < ((float) -65504.0))
                 {
@@ -507,7 +509,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat17_ = obj->covariance_urt[17];
-            if (isfinite(_sat17_))
+            if (std::isfinite(_sat17_))
             {
                 if (_sat17_ < ((float) -65504.0))
                 {
@@ -529,7 +531,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat18_ = obj->covariance_urt[18];
-            if (isfinite(_sat18_))
+            if (std::isfinite(_sat18_))
             {
                 if (_sat18_ < ((float) -65504.0))
                 {
@@ -551,7 +553,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat19_ = obj->covariance_urt[19];
-            if (isfinite(_sat19_))
+            if (std::isfinite(_sat19_))
             {
                 if (_sat19_ < ((float) -65504.0))
                 {
@@ -573,7 +575,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_PoseVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat20_ = obj->covariance_urt[20];
-            if (isfinite(_sat20_))
+            if (std::isfinite(_sat20_))
             {
                 if (_sat20_ < ((float) -65504.0))
                 {

--- a/src/types/reg/drone/physics/kinematics/cartesian/TwistVar_0_1.h
+++ b/src/types/reg/drone/physics/kinematics/cartesian/TwistVar_0_1.h
@@ -27,6 +27,8 @@
 #include <types/reg/drone/physics/kinematics/cartesian/Twist_0_1.h>
 #include <stdlib.h>
 #include <string.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/physics/kinematics/cartesian/TwistVar.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -133,7 +135,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat0_ = obj->covariance_urt[0];
-            if (isfinite(_sat0_))
+            if (std::isfinite(_sat0_))
             {
                 if (_sat0_ < ((float) -65504.0))
                 {
@@ -155,7 +157,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat1_ = obj->covariance_urt[1];
-            if (isfinite(_sat1_))
+            if (std::isfinite(_sat1_))
             {
                 if (_sat1_ < ((float) -65504.0))
                 {
@@ -177,7 +179,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat2_ = obj->covariance_urt[2];
-            if (isfinite(_sat2_))
+            if (std::isfinite(_sat2_))
             {
                 if (_sat2_ < ((float) -65504.0))
                 {
@@ -199,7 +201,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat3_ = obj->covariance_urt[3];
-            if (isfinite(_sat3_))
+            if (std::isfinite(_sat3_))
             {
                 if (_sat3_ < ((float) -65504.0))
                 {
@@ -221,7 +223,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat4_ = obj->covariance_urt[4];
-            if (isfinite(_sat4_))
+            if (std::isfinite(_sat4_))
             {
                 if (_sat4_ < ((float) -65504.0))
                 {
@@ -243,7 +245,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat5_ = obj->covariance_urt[5];
-            if (isfinite(_sat5_))
+            if (std::isfinite(_sat5_))
             {
                 if (_sat5_ < ((float) -65504.0))
                 {
@@ -265,7 +267,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat6_ = obj->covariance_urt[6];
-            if (isfinite(_sat6_))
+            if (std::isfinite(_sat6_))
             {
                 if (_sat6_ < ((float) -65504.0))
                 {
@@ -287,7 +289,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat7_ = obj->covariance_urt[7];
-            if (isfinite(_sat7_))
+            if (std::isfinite(_sat7_))
             {
                 if (_sat7_ < ((float) -65504.0))
                 {
@@ -309,7 +311,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat8_ = obj->covariance_urt[8];
-            if (isfinite(_sat8_))
+            if (std::isfinite(_sat8_))
             {
                 if (_sat8_ < ((float) -65504.0))
                 {
@@ -331,7 +333,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat9_ = obj->covariance_urt[9];
-            if (isfinite(_sat9_))
+            if (std::isfinite(_sat9_))
             {
                 if (_sat9_ < ((float) -65504.0))
                 {
@@ -353,7 +355,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat10_ = obj->covariance_urt[10];
-            if (isfinite(_sat10_))
+            if (std::isfinite(_sat10_))
             {
                 if (_sat10_ < ((float) -65504.0))
                 {
@@ -375,7 +377,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat11_ = obj->covariance_urt[11];
-            if (isfinite(_sat11_))
+            if (std::isfinite(_sat11_))
             {
                 if (_sat11_ < ((float) -65504.0))
                 {
@@ -397,7 +399,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat12_ = obj->covariance_urt[12];
-            if (isfinite(_sat12_))
+            if (std::isfinite(_sat12_))
             {
                 if (_sat12_ < ((float) -65504.0))
                 {
@@ -419,7 +421,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat13_ = obj->covariance_urt[13];
-            if (isfinite(_sat13_))
+            if (std::isfinite(_sat13_))
             {
                 if (_sat13_ < ((float) -65504.0))
                 {
@@ -441,7 +443,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat14_ = obj->covariance_urt[14];
-            if (isfinite(_sat14_))
+            if (std::isfinite(_sat14_))
             {
                 if (_sat14_ < ((float) -65504.0))
                 {
@@ -463,7 +465,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat15_ = obj->covariance_urt[15];
-            if (isfinite(_sat15_))
+            if (std::isfinite(_sat15_))
             {
                 if (_sat15_ < ((float) -65504.0))
                 {
@@ -485,7 +487,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat16_ = obj->covariance_urt[16];
-            if (isfinite(_sat16_))
+            if (std::isfinite(_sat16_))
             {
                 if (_sat16_ < ((float) -65504.0))
                 {
@@ -507,7 +509,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat17_ = obj->covariance_urt[17];
-            if (isfinite(_sat17_))
+            if (std::isfinite(_sat17_))
             {
                 if (_sat17_ < ((float) -65504.0))
                 {
@@ -529,7 +531,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat18_ = obj->covariance_urt[18];
-            if (isfinite(_sat18_))
+            if (std::isfinite(_sat18_))
             {
                 if (_sat18_ < ((float) -65504.0))
                 {
@@ -551,7 +553,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat19_ = obj->covariance_urt[19];
-            if (isfinite(_sat19_))
+            if (std::isfinite(_sat19_))
             {
                 if (_sat19_ < ((float) -65504.0))
                 {
@@ -573,7 +575,7 @@ static inline int8_t reg_drone_physics_kinematics_cartesian_TwistVar_0_1_seriali
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat20_ = obj->covariance_urt[20];
-            if (isfinite(_sat20_))
+            if (std::isfinite(_sat20_))
             {
                 if (_sat20_ < ((float) -65504.0))
                 {

--- a/src/types/reg/drone/physics/kinematics/geodetic/PointVar_0_1.h
+++ b/src/types/reg/drone/physics/kinematics/geodetic/PointVar_0_1.h
@@ -27,6 +27,8 @@
 #include <types/reg/drone/physics/kinematics/geodetic/Point_0_1.h>
 #include <stdlib.h>
 #include <string.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/physics/kinematics/geodetic/PointVar.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -133,7 +135,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PointVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat0_ = obj->covariance_urt[0];
-            if (isfinite(_sat0_))
+            if (std::isfinite(_sat0_))
             {
                 if (_sat0_ < ((float) -65504.0))
                 {
@@ -155,7 +157,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PointVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat1_ = obj->covariance_urt[1];
-            if (isfinite(_sat1_))
+            if (std::isfinite(_sat1_))
             {
                 if (_sat1_ < ((float) -65504.0))
                 {
@@ -177,7 +179,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PointVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat2_ = obj->covariance_urt[2];
-            if (isfinite(_sat2_))
+            if (std::isfinite(_sat2_))
             {
                 if (_sat2_ < ((float) -65504.0))
                 {
@@ -199,7 +201,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PointVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat3_ = obj->covariance_urt[3];
-            if (isfinite(_sat3_))
+            if (std::isfinite(_sat3_))
             {
                 if (_sat3_ < ((float) -65504.0))
                 {
@@ -221,7 +223,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PointVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat4_ = obj->covariance_urt[4];
-            if (isfinite(_sat4_))
+            if (std::isfinite(_sat4_))
             {
                 if (_sat4_ < ((float) -65504.0))
                 {
@@ -243,7 +245,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PointVar_0_1_serializ
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat5_ = obj->covariance_urt[5];
-            if (isfinite(_sat5_))
+            if (std::isfinite(_sat5_))
             {
                 if (_sat5_ < ((float) -65504.0))
                 {

--- a/src/types/reg/drone/physics/kinematics/geodetic/PoseVar_0_1.h
+++ b/src/types/reg/drone/physics/kinematics/geodetic/PoseVar_0_1.h
@@ -27,6 +27,8 @@
 #include <types/reg/drone/physics/kinematics/geodetic/Pose_0_1.h>
 #include <stdlib.h>
 #include <string.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/physics/kinematics/geodetic/PoseVar.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -133,7 +135,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat0_ = obj->covariance_urt[0];
-            if (isfinite(_sat0_))
+            if (std::isfinite(_sat0_))
             {
                 if (_sat0_ < ((float) -65504.0))
                 {
@@ -155,7 +157,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat1_ = obj->covariance_urt[1];
-            if (isfinite(_sat1_))
+            if (std::isfinite(_sat1_))
             {
                 if (_sat1_ < ((float) -65504.0))
                 {
@@ -177,7 +179,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat2_ = obj->covariance_urt[2];
-            if (isfinite(_sat2_))
+            if (std::isfinite(_sat2_))
             {
                 if (_sat2_ < ((float) -65504.0))
                 {
@@ -199,7 +201,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat3_ = obj->covariance_urt[3];
-            if (isfinite(_sat3_))
+            if (std::isfinite(_sat3_))
             {
                 if (_sat3_ < ((float) -65504.0))
                 {
@@ -221,7 +223,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat4_ = obj->covariance_urt[4];
-            if (isfinite(_sat4_))
+            if (std::isfinite(_sat4_))
             {
                 if (_sat4_ < ((float) -65504.0))
                 {
@@ -243,7 +245,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat5_ = obj->covariance_urt[5];
-            if (isfinite(_sat5_))
+            if (std::isfinite(_sat5_))
             {
                 if (_sat5_ < ((float) -65504.0))
                 {
@@ -265,7 +267,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat6_ = obj->covariance_urt[6];
-            if (isfinite(_sat6_))
+            if (std::isfinite(_sat6_))
             {
                 if (_sat6_ < ((float) -65504.0))
                 {
@@ -287,7 +289,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat7_ = obj->covariance_urt[7];
-            if (isfinite(_sat7_))
+            if (std::isfinite(_sat7_))
             {
                 if (_sat7_ < ((float) -65504.0))
                 {
@@ -309,7 +311,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat8_ = obj->covariance_urt[8];
-            if (isfinite(_sat8_))
+            if (std::isfinite(_sat8_))
             {
                 if (_sat8_ < ((float) -65504.0))
                 {
@@ -331,7 +333,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat9_ = obj->covariance_urt[9];
-            if (isfinite(_sat9_))
+            if (std::isfinite(_sat9_))
             {
                 if (_sat9_ < ((float) -65504.0))
                 {
@@ -353,7 +355,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat10_ = obj->covariance_urt[10];
-            if (isfinite(_sat10_))
+            if (std::isfinite(_sat10_))
             {
                 if (_sat10_ < ((float) -65504.0))
                 {
@@ -375,7 +377,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat11_ = obj->covariance_urt[11];
-            if (isfinite(_sat11_))
+            if (std::isfinite(_sat11_))
             {
                 if (_sat11_ < ((float) -65504.0))
                 {
@@ -397,7 +399,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat12_ = obj->covariance_urt[12];
-            if (isfinite(_sat12_))
+            if (std::isfinite(_sat12_))
             {
                 if (_sat12_ < ((float) -65504.0))
                 {
@@ -419,7 +421,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat13_ = obj->covariance_urt[13];
-            if (isfinite(_sat13_))
+            if (std::isfinite(_sat13_))
             {
                 if (_sat13_ < ((float) -65504.0))
                 {
@@ -441,7 +443,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat14_ = obj->covariance_urt[14];
-            if (isfinite(_sat14_))
+            if (std::isfinite(_sat14_))
             {
                 if (_sat14_ < ((float) -65504.0))
                 {
@@ -463,7 +465,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat15_ = obj->covariance_urt[15];
-            if (isfinite(_sat15_))
+            if (std::isfinite(_sat15_))
             {
                 if (_sat15_ < ((float) -65504.0))
                 {
@@ -485,7 +487,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat16_ = obj->covariance_urt[16];
-            if (isfinite(_sat16_))
+            if (std::isfinite(_sat16_))
             {
                 if (_sat16_ < ((float) -65504.0))
                 {
@@ -507,7 +509,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat17_ = obj->covariance_urt[17];
-            if (isfinite(_sat17_))
+            if (std::isfinite(_sat17_))
             {
                 if (_sat17_ < ((float) -65504.0))
                 {
@@ -529,7 +531,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat18_ = obj->covariance_urt[18];
-            if (isfinite(_sat18_))
+            if (std::isfinite(_sat18_))
             {
                 if (_sat18_ < ((float) -65504.0))
                 {
@@ -551,7 +553,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat19_ = obj->covariance_urt[19];
-            if (isfinite(_sat19_))
+            if (std::isfinite(_sat19_))
             {
                 if (_sat19_ < ((float) -65504.0))
                 {
@@ -573,7 +575,7 @@ static inline int8_t reg_drone_physics_kinematics_geodetic_PoseVar_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat20_ = obj->covariance_urt[20];
-            if (isfinite(_sat20_))
+            if (std::isfinite(_sat20_))
             {
                 if (_sat20_ < ((float) -65504.0))
                 {

--- a/src/types/reg/drone/physics/kinematics/translation/LinearVarTs_0_1.h
+++ b/src/types/reg/drone/physics/kinematics/translation/LinearVarTs_0_1.h
@@ -26,6 +26,8 @@
 #include <nunavut/support/serialization.h>
 #include <types/reg/drone/physics/kinematics/translation/LinearTs_0_1.h>
 #include <stdlib.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/physics/kinematics/translation/LinearVarTs.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -130,7 +132,7 @@ static inline int8_t reg_drone_physics_kinematics_translation_LinearVarTs_0_1_se
         NUNAVUT_ASSERT(offset_bits % 8U == 0U);
         NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
         float _sat0_ = obj->position_error_variance;
-        if (isfinite(_sat0_))
+        if (std::isfinite(_sat0_))
         {
             if (_sat0_ < ((float) -65504.0))
             {
@@ -153,7 +155,7 @@ static inline int8_t reg_drone_physics_kinematics_translation_LinearVarTs_0_1_se
         NUNAVUT_ASSERT(offset_bits % 8U == 0U);
         NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
         float _sat1_ = obj->velocity_error_variance;
-        if (isfinite(_sat1_))
+        if (std::isfinite(_sat1_))
         {
             if (_sat1_ < ((float) -65504.0))
             {
@@ -176,7 +178,7 @@ static inline int8_t reg_drone_physics_kinematics_translation_LinearVarTs_0_1_se
         NUNAVUT_ASSERT(offset_bits % 8U == 0U);
         NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
         float _sat2_ = obj->acceleration_error_variance;
-        if (isfinite(_sat2_))
+        if (std::isfinite(_sat2_))
         {
             if (_sat2_ < ((float) -65504.0))
             {

--- a/src/types/reg/drone/physics/kinematics/translation/Velocity1VarTs_0_1.h
+++ b/src/types/reg/drone/physics/kinematics/translation/Velocity1VarTs_0_1.h
@@ -26,6 +26,8 @@
 #include <nunavut/support/serialization.h>
 #include <types/uavcan/si/sample/velocity/Scalar_1_0.h>
 #include <stdlib.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/physics/kinematics/translation/Velocity1VarTs.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -124,7 +126,7 @@ static inline int8_t reg_drone_physics_kinematics_translation_Velocity1VarTs_0_1
         NUNAVUT_ASSERT(offset_bits % 8U == 0U);
         NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
         float _sat0_ = obj->error_variance;
-        if (isfinite(_sat0_))
+        if (std::isfinite(_sat0_))
         {
             if (_sat0_ < ((float) -65504.0))
             {

--- a/src/types/reg/drone/physics/kinematics/translation/Velocity3Var_0_1.h
+++ b/src/types/reg/drone/physics/kinematics/translation/Velocity3Var_0_1.h
@@ -27,6 +27,8 @@
 #include <types/uavcan/si/sample/velocity/Vector3_1_0.h>
 #include <stdlib.h>
 #include <string.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/physics/kinematics/translation/Velocity3Var.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -133,7 +135,7 @@ static inline int8_t reg_drone_physics_kinematics_translation_Velocity3Var_0_1_s
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat0_ = obj->covariance_urt[0];
-            if (isfinite(_sat0_))
+            if (std::isfinite(_sat0_))
             {
                 if (_sat0_ < ((float) -65504.0))
                 {
@@ -155,7 +157,7 @@ static inline int8_t reg_drone_physics_kinematics_translation_Velocity3Var_0_1_s
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat1_ = obj->covariance_urt[1];
-            if (isfinite(_sat1_))
+            if (std::isfinite(_sat1_))
             {
                 if (_sat1_ < ((float) -65504.0))
                 {
@@ -177,7 +179,7 @@ static inline int8_t reg_drone_physics_kinematics_translation_Velocity3Var_0_1_s
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat2_ = obj->covariance_urt[2];
-            if (isfinite(_sat2_))
+            if (std::isfinite(_sat2_))
             {
                 if (_sat2_ < ((float) -65504.0))
                 {
@@ -199,7 +201,7 @@ static inline int8_t reg_drone_physics_kinematics_translation_Velocity3Var_0_1_s
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat3_ = obj->covariance_urt[3];
-            if (isfinite(_sat3_))
+            if (std::isfinite(_sat3_))
             {
                 if (_sat3_ < ((float) -65504.0))
                 {
@@ -221,7 +223,7 @@ static inline int8_t reg_drone_physics_kinematics_translation_Velocity3Var_0_1_s
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat4_ = obj->covariance_urt[4];
-            if (isfinite(_sat4_))
+            if (std::isfinite(_sat4_))
             {
                 if (_sat4_ < ((float) -65504.0))
                 {
@@ -243,7 +245,7 @@ static inline int8_t reg_drone_physics_kinematics_translation_Velocity3Var_0_1_s
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat5_ = obj->covariance_urt[5];
-            if (isfinite(_sat5_))
+            if (std::isfinite(_sat5_))
             {
                 if (_sat5_ < ((float) -65504.0))
                 {

--- a/src/types/reg/drone/physics/thermodynamics/PressureTempVarTs_0_1.h
+++ b/src/types/reg/drone/physics/thermodynamics/PressureTempVarTs_0_1.h
@@ -29,6 +29,8 @@
 #include <types/uavcan/time/SynchronizedTimestamp_1_0.h>
 #include <stdlib.h>
 #include <string.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/physics/thermodynamics/PressureTempVarTs.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -205,7 +207,7 @@ static inline int8_t reg_drone_physics_thermodynamics_PressureTempVarTs_0_1_seri
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat0_ = obj->covariance_urt[0];
-            if (isfinite(_sat0_))
+            if (std::isfinite(_sat0_))
             {
                 if (_sat0_ < ((float) -65504.0))
                 {
@@ -227,7 +229,7 @@ static inline int8_t reg_drone_physics_thermodynamics_PressureTempVarTs_0_1_seri
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat1_ = obj->covariance_urt[1];
-            if (isfinite(_sat1_))
+            if (std::isfinite(_sat1_))
             {
                 if (_sat1_ < ((float) -65504.0))
                 {
@@ -249,7 +251,7 @@ static inline int8_t reg_drone_physics_thermodynamics_PressureTempVarTs_0_1_seri
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat2_ = obj->covariance_urt[2];
-            if (isfinite(_sat2_))
+            if (std::isfinite(_sat2_))
             {
                 if (_sat2_ < ((float) -65504.0))
                 {

--- a/src/types/reg/drone/service/actuator/common/sp/Scalar_0_1.h
+++ b/src/types/reg/drone/service/actuator/common/sp/Scalar_0_1.h
@@ -25,6 +25,8 @@
 
 #include <nunavut/support/serialization.h>
 #include <stdlib.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/service/actuator/common/sp/Scalar.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -101,7 +103,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Scalar_0_1_serialize_(
         NUNAVUT_ASSERT(offset_bits % 8U == 0U);
         NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
         float _sat0_ = obj->value;
-        if (isfinite(_sat0_))
+        if (std::isfinite(_sat0_))
         {
             if (_sat0_ < ((float) -65504.0))
             {

--- a/src/types/reg/drone/service/actuator/common/sp/Vector2_0_1.h
+++ b/src/types/reg/drone/service/actuator/common/sp/Vector2_0_1.h
@@ -26,6 +26,8 @@
 #include <nunavut/support/serialization.h>
 #include <stdlib.h>
 #include <string.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/service/actuator/common/sp/Vector2.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -110,7 +112,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector2_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat0_ = obj->value[0];
-            if (isfinite(_sat0_))
+            if (std::isfinite(_sat0_))
             {
                 if (_sat0_ < ((float) -65504.0))
                 {
@@ -132,7 +134,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector2_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat1_ = obj->value[1];
-            if (isfinite(_sat1_))
+            if (std::isfinite(_sat1_))
             {
                 if (_sat1_ < ((float) -65504.0))
                 {

--- a/src/types/reg/drone/service/actuator/common/sp/Vector31_0_1.h
+++ b/src/types/reg/drone/service/actuator/common/sp/Vector31_0_1.h
@@ -26,6 +26,8 @@
 #include <nunavut/support/serialization.h>
 #include <stdlib.h>
 #include <string.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/service/actuator/common/sp/Vector31.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -110,7 +112,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat0_ = obj->value[0];
-            if (isfinite(_sat0_))
+            if (std::isfinite(_sat0_))
             {
                 if (_sat0_ < ((float) -65504.0))
                 {
@@ -132,7 +134,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat1_ = obj->value[1];
-            if (isfinite(_sat1_))
+            if (std::isfinite(_sat1_))
             {
                 if (_sat1_ < ((float) -65504.0))
                 {
@@ -154,7 +156,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat2_ = obj->value[2];
-            if (isfinite(_sat2_))
+            if (std::isfinite(_sat2_))
             {
                 if (_sat2_ < ((float) -65504.0))
                 {
@@ -176,7 +178,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat3_ = obj->value[3];
-            if (isfinite(_sat3_))
+            if (std::isfinite(_sat3_))
             {
                 if (_sat3_ < ((float) -65504.0))
                 {
@@ -198,7 +200,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat4_ = obj->value[4];
-            if (isfinite(_sat4_))
+            if (std::isfinite(_sat4_))
             {
                 if (_sat4_ < ((float) -65504.0))
                 {
@@ -220,7 +222,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat5_ = obj->value[5];
-            if (isfinite(_sat5_))
+            if (std::isfinite(_sat5_))
             {
                 if (_sat5_ < ((float) -65504.0))
                 {
@@ -242,7 +244,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat6_ = obj->value[6];
-            if (isfinite(_sat6_))
+            if (std::isfinite(_sat6_))
             {
                 if (_sat6_ < ((float) -65504.0))
                 {
@@ -264,7 +266,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat7_ = obj->value[7];
-            if (isfinite(_sat7_))
+            if (std::isfinite(_sat7_))
             {
                 if (_sat7_ < ((float) -65504.0))
                 {
@@ -286,7 +288,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat8_ = obj->value[8];
-            if (isfinite(_sat8_))
+            if (std::isfinite(_sat8_))
             {
                 if (_sat8_ < ((float) -65504.0))
                 {
@@ -308,7 +310,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat9_ = obj->value[9];
-            if (isfinite(_sat9_))
+            if (std::isfinite(_sat9_))
             {
                 if (_sat9_ < ((float) -65504.0))
                 {
@@ -330,7 +332,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat10_ = obj->value[10];
-            if (isfinite(_sat10_))
+            if (std::isfinite(_sat10_))
             {
                 if (_sat10_ < ((float) -65504.0))
                 {
@@ -352,7 +354,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat11_ = obj->value[11];
-            if (isfinite(_sat11_))
+            if (std::isfinite(_sat11_))
             {
                 if (_sat11_ < ((float) -65504.0))
                 {
@@ -374,7 +376,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat12_ = obj->value[12];
-            if (isfinite(_sat12_))
+            if (std::isfinite(_sat12_))
             {
                 if (_sat12_ < ((float) -65504.0))
                 {
@@ -396,7 +398,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat13_ = obj->value[13];
-            if (isfinite(_sat13_))
+            if (std::isfinite(_sat13_))
             {
                 if (_sat13_ < ((float) -65504.0))
                 {
@@ -418,7 +420,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat14_ = obj->value[14];
-            if (isfinite(_sat14_))
+            if (std::isfinite(_sat14_))
             {
                 if (_sat14_ < ((float) -65504.0))
                 {
@@ -440,7 +442,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat15_ = obj->value[15];
-            if (isfinite(_sat15_))
+            if (std::isfinite(_sat15_))
             {
                 if (_sat15_ < ((float) -65504.0))
                 {
@@ -462,7 +464,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat16_ = obj->value[16];
-            if (isfinite(_sat16_))
+            if (std::isfinite(_sat16_))
             {
                 if (_sat16_ < ((float) -65504.0))
                 {
@@ -484,7 +486,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat17_ = obj->value[17];
-            if (isfinite(_sat17_))
+            if (std::isfinite(_sat17_))
             {
                 if (_sat17_ < ((float) -65504.0))
                 {
@@ -506,7 +508,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat18_ = obj->value[18];
-            if (isfinite(_sat18_))
+            if (std::isfinite(_sat18_))
             {
                 if (_sat18_ < ((float) -65504.0))
                 {
@@ -528,7 +530,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat19_ = obj->value[19];
-            if (isfinite(_sat19_))
+            if (std::isfinite(_sat19_))
             {
                 if (_sat19_ < ((float) -65504.0))
                 {
@@ -550,7 +552,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat20_ = obj->value[20];
-            if (isfinite(_sat20_))
+            if (std::isfinite(_sat20_))
             {
                 if (_sat20_ < ((float) -65504.0))
                 {
@@ -572,7 +574,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat21_ = obj->value[21];
-            if (isfinite(_sat21_))
+            if (std::isfinite(_sat21_))
             {
                 if (_sat21_ < ((float) -65504.0))
                 {
@@ -594,7 +596,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat22_ = obj->value[22];
-            if (isfinite(_sat22_))
+            if (std::isfinite(_sat22_))
             {
                 if (_sat22_ < ((float) -65504.0))
                 {
@@ -616,7 +618,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat23_ = obj->value[23];
-            if (isfinite(_sat23_))
+            if (std::isfinite(_sat23_))
             {
                 if (_sat23_ < ((float) -65504.0))
                 {
@@ -638,7 +640,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat24_ = obj->value[24];
-            if (isfinite(_sat24_))
+            if (std::isfinite(_sat24_))
             {
                 if (_sat24_ < ((float) -65504.0))
                 {
@@ -660,7 +662,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat25_ = obj->value[25];
-            if (isfinite(_sat25_))
+            if (std::isfinite(_sat25_))
             {
                 if (_sat25_ < ((float) -65504.0))
                 {
@@ -682,7 +684,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat26_ = obj->value[26];
-            if (isfinite(_sat26_))
+            if (std::isfinite(_sat26_))
             {
                 if (_sat26_ < ((float) -65504.0))
                 {
@@ -704,7 +706,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat27_ = obj->value[27];
-            if (isfinite(_sat27_))
+            if (std::isfinite(_sat27_))
             {
                 if (_sat27_ < ((float) -65504.0))
                 {
@@ -726,7 +728,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat28_ = obj->value[28];
-            if (isfinite(_sat28_))
+            if (std::isfinite(_sat28_))
             {
                 if (_sat28_ < ((float) -65504.0))
                 {
@@ -748,7 +750,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat29_ = obj->value[29];
-            if (isfinite(_sat29_))
+            if (std::isfinite(_sat29_))
             {
                 if (_sat29_ < ((float) -65504.0))
                 {
@@ -770,7 +772,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector31_0_1_serialize
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat30_ = obj->value[30];
-            if (isfinite(_sat30_))
+            if (std::isfinite(_sat30_))
             {
                 if (_sat30_ < ((float) -65504.0))
                 {

--- a/src/types/reg/drone/service/actuator/common/sp/Vector3_0_1.h
+++ b/src/types/reg/drone/service/actuator/common/sp/Vector3_0_1.h
@@ -26,6 +26,8 @@
 #include <nunavut/support/serialization.h>
 #include <stdlib.h>
 #include <string.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/service/actuator/common/sp/Vector3.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -110,7 +112,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector3_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat0_ = obj->value[0];
-            if (isfinite(_sat0_))
+            if (std::isfinite(_sat0_))
             {
                 if (_sat0_ < ((float) -65504.0))
                 {
@@ -132,7 +134,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector3_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat1_ = obj->value[1];
-            if (isfinite(_sat1_))
+            if (std::isfinite(_sat1_))
             {
                 if (_sat1_ < ((float) -65504.0))
                 {
@@ -154,7 +156,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector3_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat2_ = obj->value[2];
-            if (isfinite(_sat2_))
+            if (std::isfinite(_sat2_))
             {
                 if (_sat2_ < ((float) -65504.0))
                 {

--- a/src/types/reg/drone/service/actuator/common/sp/Vector4_0_1.h
+++ b/src/types/reg/drone/service/actuator/common/sp/Vector4_0_1.h
@@ -26,6 +26,8 @@
 #include <nunavut/support/serialization.h>
 #include <stdlib.h>
 #include <string.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/service/actuator/common/sp/Vector4.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -110,7 +112,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector4_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat0_ = obj->value[0];
-            if (isfinite(_sat0_))
+            if (std::isfinite(_sat0_))
             {
                 if (_sat0_ < ((float) -65504.0))
                 {
@@ -132,7 +134,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector4_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat1_ = obj->value[1];
-            if (isfinite(_sat1_))
+            if (std::isfinite(_sat1_))
             {
                 if (_sat1_ < ((float) -65504.0))
                 {
@@ -154,7 +156,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector4_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat2_ = obj->value[2];
-            if (isfinite(_sat2_))
+            if (std::isfinite(_sat2_))
             {
                 if (_sat2_ < ((float) -65504.0))
                 {
@@ -176,7 +178,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector4_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat3_ = obj->value[3];
-            if (isfinite(_sat3_))
+            if (std::isfinite(_sat3_))
             {
                 if (_sat3_ < ((float) -65504.0))
                 {

--- a/src/types/reg/drone/service/actuator/common/sp/Vector6_0_1.h
+++ b/src/types/reg/drone/service/actuator/common/sp/Vector6_0_1.h
@@ -26,6 +26,8 @@
 #include <nunavut/support/serialization.h>
 #include <stdlib.h>
 #include <string.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/service/actuator/common/sp/Vector6.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -110,7 +112,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector6_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat0_ = obj->value[0];
-            if (isfinite(_sat0_))
+            if (std::isfinite(_sat0_))
             {
                 if (_sat0_ < ((float) -65504.0))
                 {
@@ -132,7 +134,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector6_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat1_ = obj->value[1];
-            if (isfinite(_sat1_))
+            if (std::isfinite(_sat1_))
             {
                 if (_sat1_ < ((float) -65504.0))
                 {
@@ -154,7 +156,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector6_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat2_ = obj->value[2];
-            if (isfinite(_sat2_))
+            if (std::isfinite(_sat2_))
             {
                 if (_sat2_ < ((float) -65504.0))
                 {
@@ -176,7 +178,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector6_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat3_ = obj->value[3];
-            if (isfinite(_sat3_))
+            if (std::isfinite(_sat3_))
             {
                 if (_sat3_ < ((float) -65504.0))
                 {
@@ -198,7 +200,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector6_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat4_ = obj->value[4];
-            if (isfinite(_sat4_))
+            if (std::isfinite(_sat4_))
             {
                 if (_sat4_ < ((float) -65504.0))
                 {
@@ -220,7 +222,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector6_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat5_ = obj->value[5];
-            if (isfinite(_sat5_))
+            if (std::isfinite(_sat5_))
             {
                 if (_sat5_ < ((float) -65504.0))
                 {

--- a/src/types/reg/drone/service/actuator/common/sp/Vector8_0_1.h
+++ b/src/types/reg/drone/service/actuator/common/sp/Vector8_0_1.h
@@ -26,6 +26,8 @@
 #include <nunavut/support/serialization.h>
 #include <stdlib.h>
 #include <string.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/service/actuator/common/sp/Vector8.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -110,7 +112,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector8_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat0_ = obj->value[0];
-            if (isfinite(_sat0_))
+            if (std::isfinite(_sat0_))
             {
                 if (_sat0_ < ((float) -65504.0))
                 {
@@ -132,7 +134,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector8_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat1_ = obj->value[1];
-            if (isfinite(_sat1_))
+            if (std::isfinite(_sat1_))
             {
                 if (_sat1_ < ((float) -65504.0))
                 {
@@ -154,7 +156,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector8_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat2_ = obj->value[2];
-            if (isfinite(_sat2_))
+            if (std::isfinite(_sat2_))
             {
                 if (_sat2_ < ((float) -65504.0))
                 {
@@ -176,7 +178,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector8_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat3_ = obj->value[3];
-            if (isfinite(_sat3_))
+            if (std::isfinite(_sat3_))
             {
                 if (_sat3_ < ((float) -65504.0))
                 {
@@ -198,7 +200,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector8_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat4_ = obj->value[4];
-            if (isfinite(_sat4_))
+            if (std::isfinite(_sat4_))
             {
                 if (_sat4_ < ((float) -65504.0))
                 {
@@ -220,7 +222,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector8_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat5_ = obj->value[5];
-            if (isfinite(_sat5_))
+            if (std::isfinite(_sat5_))
             {
                 if (_sat5_ < ((float) -65504.0))
                 {
@@ -242,7 +244,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector8_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat6_ = obj->value[6];
-            if (isfinite(_sat6_))
+            if (std::isfinite(_sat6_))
             {
                 if (_sat6_ < ((float) -65504.0))
                 {
@@ -264,7 +266,7 @@ static inline int8_t reg_drone_service_actuator_common_sp_Vector8_0_1_serialize_
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat7_ = obj->value[7];
-            if (isfinite(_sat7_))
+            if (std::isfinite(_sat7_))
             {
                 if (_sat7_ < ((float) -65504.0))
                 {

--- a/src/types/reg/drone/service/battery/Status_0_2.h
+++ b/src/types/reg/drone/service/battery/Status_0_2.h
@@ -30,6 +30,8 @@
 #include <types/uavcan/si/unit/temperature/Scalar_1_0.h>
 #include <stdint.h>
 #include <stdlib.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/service/battery/Status.0.2.uavcan is trying to use a serialization library that was compiled with "
@@ -293,7 +295,7 @@ static inline int8_t reg_drone_service_battery_Status_0_2_serialize_(
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat0_ = obj->cell_voltages.elements[_index0_];
-            if (isfinite(_sat0_))
+            if (std::isfinite(_sat0_))
             {
                 if (_sat0_ < ((float) -65504.0))
                 {

--- a/src/types/reg/drone/service/gnss/DilutionOfPrecision_0_1.h
+++ b/src/types/reg/drone/service/gnss/DilutionOfPrecision_0_1.h
@@ -25,6 +25,8 @@
 
 #include <nunavut/support/serialization.h>
 #include <stdlib.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/reg/drone/service/gnss/DilutionOfPrecision.0.1.uavcan is trying to use a serialization library that was compiled with "
@@ -119,7 +121,7 @@ static inline int8_t reg_drone_service_gnss_DilutionOfPrecision_0_1_serialize_(
         NUNAVUT_ASSERT(offset_bits % 8U == 0U);
         NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
         float _sat0_ = obj->geometric;
-        if (isfinite(_sat0_))
+        if (std::isfinite(_sat0_))
         {
             if (_sat0_ < ((float) -65504.0))
             {
@@ -142,7 +144,7 @@ static inline int8_t reg_drone_service_gnss_DilutionOfPrecision_0_1_serialize_(
         NUNAVUT_ASSERT(offset_bits % 8U == 0U);
         NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
         float _sat1_ = obj->position;
-        if (isfinite(_sat1_))
+        if (std::isfinite(_sat1_))
         {
             if (_sat1_ < ((float) -65504.0))
             {
@@ -165,7 +167,7 @@ static inline int8_t reg_drone_service_gnss_DilutionOfPrecision_0_1_serialize_(
         NUNAVUT_ASSERT(offset_bits % 8U == 0U);
         NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
         float _sat2_ = obj->horizontal;
-        if (isfinite(_sat2_))
+        if (std::isfinite(_sat2_))
         {
             if (_sat2_ < ((float) -65504.0))
             {
@@ -188,7 +190,7 @@ static inline int8_t reg_drone_service_gnss_DilutionOfPrecision_0_1_serialize_(
         NUNAVUT_ASSERT(offset_bits % 8U == 0U);
         NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
         float _sat3_ = obj->vertical;
-        if (isfinite(_sat3_))
+        if (std::isfinite(_sat3_))
         {
             if (_sat3_ < ((float) -65504.0))
             {
@@ -211,7 +213,7 @@ static inline int8_t reg_drone_service_gnss_DilutionOfPrecision_0_1_serialize_(
         NUNAVUT_ASSERT(offset_bits % 8U == 0U);
         NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
         float _sat4_ = obj->time;
-        if (isfinite(_sat4_))
+        if (std::isfinite(_sat4_))
         {
             if (_sat4_ < ((float) -65504.0))
             {
@@ -234,7 +236,7 @@ static inline int8_t reg_drone_service_gnss_DilutionOfPrecision_0_1_serialize_(
         NUNAVUT_ASSERT(offset_bits % 8U == 0U);
         NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
         float _sat5_ = obj->northing;
-        if (isfinite(_sat5_))
+        if (std::isfinite(_sat5_))
         {
             if (_sat5_ < ((float) -65504.0))
             {
@@ -257,7 +259,7 @@ static inline int8_t reg_drone_service_gnss_DilutionOfPrecision_0_1_serialize_(
         NUNAVUT_ASSERT(offset_bits % 8U == 0U);
         NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
         float _sat6_ = obj->easting;
-        if (isfinite(_sat6_))
+        if (std::isfinite(_sat6_))
         {
             if (_sat6_ < ((float) -65504.0))
             {

--- a/src/types/uavcan/primitive/array/Real16_1_0.h
+++ b/src/types/uavcan/primitive/array/Real16_1_0.h
@@ -25,6 +25,8 @@
 
 #include <nunavut/support/serialization.h>
 #include <stdlib.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/uavcan/primitive/array/Real16.1.0.uavcan is trying to use a serialization library that was compiled with "
@@ -121,7 +123,7 @@ static inline int8_t uavcan_primitive_array_Real16_1_0_serialize_(
             NUNAVUT_ASSERT(offset_bits % 8U == 0U);
             NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
             float _sat0_ = obj->value.elements[_index0_];
-            if (isfinite(_sat0_))
+            if (std::isfinite(_sat0_))
             {
                 if (_sat0_ < ((float) -65504.0))
                 {

--- a/src/types/uavcan/primitive/scalar/Real16_1_0.h
+++ b/src/types/uavcan/primitive/scalar/Real16_1_0.h
@@ -25,6 +25,8 @@
 
 #include <nunavut/support/serialization.h>
 #include <stdlib.h>
+#undef infinite
+#include <cmath>
 
 static_assert( NUNAVUT_SUPPORT_LANGUAGE_OPTION_TARGET_ENDIANNESS == 1693710260,
               "/home/alex/projects/107-systems/public_regulated_data_types/uavcan/primitive/scalar/Real16.1.0.uavcan is trying to use a serialization library that was compiled with "
@@ -101,7 +103,7 @@ static inline int8_t uavcan_primitive_scalar_Real16_1_0_serialize_(
         NUNAVUT_ASSERT(offset_bits % 8U == 0U);
         NUNAVUT_ASSERT((offset_bits + 16ULL) <= (capacity_bytes * 8U));
         float _sat0_ = obj->value;
-        if (isfinite(_sat0_))
+        if (std::isfinite(_sat0_))
         {
             if (_sat0_ < ((float) -65504.0))
             {


### PR DESCRIPTION
Undefining isfinite and replacing its usage with std::finite fixes macro expansion issues when compiling for ESP32.

This fixes #83.