### PR TITLE
Use modern API of `arduino/compile-sketches` action

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -17,7 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      LIBRARIES: 107-Arduino-MCP2515
+      LIBRARIES: |
+        # Install the library from the local path.
+        - source-path: ./
+        - name: 107-Arduino-MCP2515
 
     strategy:
       fail-fast: false
@@ -55,7 +58,7 @@ jobs:
           fqbn: ${{ matrix.board.fqbn }}
           platforms: ${{ matrix.board.platforms }}
           libraries: ${{ env.LIBRARIES }}
-          enable-size-deltas-report: true
+          enable-deltas-report: true
 
       - name: Save memory usage change report as artifact
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
The API of the `arduino/compile-sketches` GitHub Actions action used to compile the library's example sketches in the
"Compile Examples" CI workflow has evolved over time. Although measures were taken to provide backwards compatibility for
the old API, it turns out that the GitHub Actions behavior of creating environment variables for arbitrary input names
relied upon for still recognizing the old inputs is not consistent across action types. It works fine for the Docker
container action type originally used by `arduino/compile-sketches`, but not for the new "Composite Run Steps" action
type we switched to (https://github.com/arduino/compile-sketches/pull/14).

This change resulted in sketch data deltas no longer being generated due to the workflow's use of the unsupported input
name `enable-size-deltas-report`. This resulted in failed runs of the "Report Size Deltas" workflow due to the reports not having
the required deltas data. Example:
https://github.com/107-systems/107-Arduino-UAVCAN/actions/runs/955404693
```
Traceback (most recent call last):
  File "/reportsizedeltas/reportsizedeltas.py", line 737, in <module>
    main()  # pragma: no cover
  File "/reportsizedeltas/reportsizedeltas.py", line 32, in main
    report_size_deltas.report_size_deltas()
  File "/reportsizedeltas/reportsizedeltas.py", line 95, in report_size_deltas
    self.report_size_deltas_from_workflow_artifacts()
  File "/reportsizedeltas/reportsizedeltas.py", line 149, in report_size_deltas_from_workflow_artifacts
    sketches_reports = self.get_sketches_reports(artifact_folder_object=artifact_folder_object)
  File "/reportsizedeltas/reportsizedeltas.py", line 295, in get_sketches_reports
    not in report_data[self.ReportKeys.boards][0][self.ReportKeys.sizes][0])
KeyError: 'sizes'
```

The fix is simply to update to the new input name.

I went ahead and updated to the new YAML array style of the `libraries` input as well. There is still backwards compatibility for
the old API in this case due to the input name not having changed, but only the data format. However, the old data format
is deprecated so it's safest to update.