### PR TITLE
Move prev variables for heartbeat frequency into global scope

### DIFF
--- a/examples/UAVCAN-Blink/UAVCAN-Blink.ino
+++ b/examples/UAVCAN-Blink/UAVCAN-Blink.ino
@@ -71,6 +71,8 @@ ArduinoUAVCAN uc(13, transmitCanFrame);
 
 Heartbeat_1_0<> hb;
 
+static unsigned long prev = 0;
+
 /**************************************************************************************
  * SETUP/LOOP
  **************************************************************************************/
@@ -126,7 +128,6 @@ void loop()
   hb = Heartbeat_1_0<>::Mode::OPERATIONAL;
 
   /* Publish the heartbeat once/second */
-  static unsigned long prev = 0;
   unsigned long const now = millis();
   if(now - prev > 1000) {
     uc.publish(hb);

--- a/examples/UAVCAN-GNSS-Node/UAVCAN-GNSS-Node.ino
+++ b/examples/UAVCAN-GNSS-Node/UAVCAN-GNSS-Node.ino
@@ -113,6 +113,8 @@ UavcanNodeConfiguration node_config = UAVCAN_NODE_INITIAL_CONFIGURATION;
 
 DEBUG_INSTANCE(120, Serial);
 
+static unsigned long prev_heartbeat = 0;
+
 /**************************************************************************************
  * SETUP/LOOP
  **************************************************************************************/
@@ -154,7 +156,6 @@ void loop()
 
   /* Publish the node heartbeat.
    */
-  static unsigned long prev_heartbeat = 0;
   if ((now - prev_heartbeat) > node_config.heartbeat_period_ms) {
     heartbeat::publish(uavcan_hdl, now / 1000, node_data.mode);
     prev_heartbeat = now;

--- a/examples/UAVCAN-Heartbeat-Publish/UAVCAN-Heartbeat-Publish.ino
+++ b/examples/UAVCAN-Heartbeat-Publish/UAVCAN-Heartbeat-Publish.ino
@@ -53,6 +53,8 @@ ArduinoUAVCAN uc(13, transmitCanFrame);
 
 Heartbeat_1_0<> hb;
 
+static unsigned long prev = 0;
+
 /**************************************************************************************
  * SETUP/LOOP
  **************************************************************************************/
@@ -90,7 +92,6 @@ void loop()
   hb = Heartbeat_1_0<>::Mode::OPERATIONAL;
 
   /* Publish the heartbeat once/second */
-  static unsigned long prev = 0;
   unsigned long const now = millis();
   if(now - prev > 1000) {
     uc.publish(hb);

--- a/examples/UAVCAN-ToF-Distance-Sensor-Node/UAVCAN-ToF-Distance-Sensor-Node.ino
+++ b/examples/UAVCAN-ToF-Distance-Sensor-Node/UAVCAN-ToF-Distance-Sensor-Node.ino
@@ -118,6 +118,8 @@ ArduinoTMF8801 tmf8801{i2c_generic_write, i2c_generic_read, delay, TMF8801_DEFAU
 
 DEBUG_INSTANCE(120, Serial);
 
+static unsigned long prev_heartbeat = 0;
+
 /**************************************************************************************
  * SETUP/LOOP
  **************************************************************************************/
@@ -168,7 +170,6 @@ void loop()
 
   /* Publish the node heartbeat.
    */
-  static unsigned long prev_heartbeat = 0;
   if ((now - prev_heartbeat) > node_config.heartbeat_period_ms) {
     heartbeat::publish(uavcan_hdl, now / 1000, node_data.mode);
     prev_heartbeat = now;


### PR DESCRIPTION
This should fix https://github.com/107-systems/107-Arduino-UAVCAN/issues/131, the prev_heartbeat is set to 0 at each iteration of the loop:

https://github.com/107-systems/107-Arduino-UAVCAN/blob/5e03e6e795a65d0b3507560f82381d3f70a165e8/examples/UAVCAN-ToF-Distance-Sensor-Node/UAVCAN-ToF-Distance-Sensor-Node.ino#L171